### PR TITLE
Add Message family components. Specify type for some events. Fixes.

### DIFF
--- a/facade/src/main/scala/react/semanticui/addons/radio/Radio.scala
+++ b/facade/src/main/scala/react/semanticui/addons/radio/Radio.scala
@@ -24,13 +24,13 @@ final case class Radio(
   indeterminate:        js.UndefOr[Boolean]           = js.undefined,
   label:                js.UndefOr[VdomNode]          = js.undefined,
   name:                 js.UndefOr[String]            = js.undefined,
-  onChangeE:            js.UndefOr[Checkbox.Event]    = js.undefined,
+  onChangeE:            js.UndefOr[Radio.Event]       = js.undefined,
   onChange:             js.UndefOr[Callback]          = js.undefined,
-  onClickE:             js.UndefOr[Checkbox.Event]    = js.undefined,
+  onClickE:             js.UndefOr[Radio.Event]       = js.undefined,
   onClick:              js.UndefOr[Callback]          = js.undefined,
-  onMouseDownE:         js.UndefOr[Checkbox.Event]    = js.undefined,
+  onMouseDownE:         js.UndefOr[Radio.Event]       = js.undefined,
   onMouseDown:          js.UndefOr[Callback]          = js.undefined,
-  onMouseUpE:           js.UndefOr[Checkbox.Event]    = js.undefined,
+  onMouseUpE:           js.UndefOr[Radio.Event]       = js.undefined,
   onMouseUp:            js.UndefOr[Callback]          = js.undefined,
   radio:                js.UndefOr[Boolean]           = js.undefined,
   readOnly:             js.UndefOr[Boolean]           = js.undefined,
@@ -45,8 +45,8 @@ final case class Radio(
 }
 
 object Radio {
-  type Event            = (ReactMouseEvent, js.Object) => Callback
-  private type RawEvent = js.Function2[ReactMouseEvent, js.Object, Unit]
+  type Event            = (ReactMouseEvent, RadioProps) => Callback
+  private type RawEvent = js.Function2[ReactMouseEvent, RadioProps, Unit]
 
   @js.native
   @JSImport("semantic-ui-react", "Radio")

--- a/facade/src/main/scala/react/semanticui/collections/message/Message.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/Message.scala
@@ -13,7 +13,6 @@ import react.semanticui.{ raw => suiraw }
 import react.semanticui.elements.icon.Icon.IconProps
 import react.semanticui.elements.icon.Icon
 
-
 final case class Message(
   as:                    js.UndefOr[AsC]                                           = js.undefined,
   attached:              js.UndefOr[MessageAttached]                               = js.undefined,
@@ -81,7 +80,8 @@ object Message {
     var compact: js.UndefOr[Boolean] = js.undefined
 
     /** Shorthand for primary content. */
-    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageContent.MessageContentProps]] = js.undefined
+    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageContent.MessageContentProps]] =
+      js.undefined
 
     /** A message may be formatted to display a negative message. Same as `negative`. */
     var error: js.UndefOr[Boolean] = js.undefined
@@ -90,7 +90,8 @@ object Message {
     var floating: js.UndefOr[Boolean] = js.undefined
 
     /** Shorthand for MessageHeader. */
-    var header: js.UndefOr[suiraw.SemanticShorthandItem[MessageHeader.MessageHeaderProps]] = js.undefined
+    var header: js.UndefOr[suiraw.SemanticShorthandItem[MessageHeader.MessageHeaderProps]] =
+      js.undefined
 
     /** A message can be hidden. */
     var hidden: js.UndefOr[Boolean] = js.undefined
@@ -102,18 +103,19 @@ object Message {
     var info: js.UndefOr[Boolean] = js.undefined
 
     /** Array shorthand items for the MessageList. Mutually exclusive with children. */
-    var list: js.UndefOr[suiraw.SemanticShorthandOrArray[MessageList.MessageListProps]] = js.undefined
+    var list: js.UndefOr[suiraw.SemanticShorthandOrArray[MessageList.MessageListProps]] =
+      js.undefined
 
     /** A message may be formatted to display a negative message. Same as `error`. */
     var negative: js.UndefOr[Boolean] = js.undefined
 
     /**
-     * A message that the user can choose to hide.
-     * Called when the user clicks the "x" icon. This also adds the "x" icon.
-     *
-     * @param {SyntheticEvent} event - React's original SyntheticEvent.
-     * @param {object} data - All props.
-     */
+      * A message that the user can choose to hide.
+      * Called when the user clicks the "x" icon. This also adds the "x" icon.
+      *
+      * @param {SyntheticEvent} event - React's original SyntheticEvent.
+      * @param {object} data - All props.
+      */
     var onDismiss: js.UndefOr[js.Function2[ReactEvent, MessageProps, Unit]] = js.undefined
 
     /** A message may be formatted to display a positive message.  Same as `success`. */

--- a/facade/src/main/scala/react/semanticui/collections/message/Message.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/Message.scala
@@ -1,0 +1,216 @@
+package react.semanticui.collections.message
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.VdomNode
+import japgolly.scalajs.react.raw.React
+import react.common.style._
+import react.common._
+import react.semanticui._
+import react.semanticui.{ raw => suiraw }
+import react.semanticui.elements.icon.Icon.IconProps
+import react.semanticui.elements.icon.Icon
+
+
+final case class Message(
+  as:                    js.UndefOr[AsC]                                           = js.undefined,
+  attached:              js.UndefOr[MessageAttached]                               = js.undefined,
+  child:                 js.UndefOr[VdomNode]                                      = js.undefined,
+  className:             js.UndefOr[String]                                        = js.undefined,
+  clazz:                 js.UndefOr[Css]                                           = js.undefined,
+  color:                 js.UndefOr[SemanticColor]                                 = js.undefined,
+  compact:               js.UndefOr[Boolean]                                       = js.undefined,
+  content:               js.UndefOr[VdomNode | MessageContent.MessageContentProps] = js.undefined,
+  error:                 js.UndefOr[Boolean]                                       = js.undefined,
+  floating:              js.UndefOr[Boolean]                                       = js.undefined,
+  header:                js.UndefOr[VdomNode | MessageHeader.MessageHeaderProps]   = js.undefined,
+  hidden:                js.UndefOr[Boolean]                                       = js.undefined,
+  icon:                  js.UndefOr[Icon]                                          = js.undefined,
+  info:                  js.UndefOr[Boolean]                                       = js.undefined,
+  list:                  js.UndefOr[Seq[VdomNode] | MessageList.MessageListProps]  = js.undefined,
+  negative:              js.UndefOr[Boolean]                                       = js.undefined,
+  onDismissE:            js.UndefOr[Message.OnDismiss]                             = js.undefined,
+  onDismiss:             js.UndefOr[Callback]                                      = js.undefined,
+  positive:              js.UndefOr[Boolean]                                       = js.undefined,
+  size:                  js.UndefOr[MessageSize]                                   = js.undefined,
+  success:               js.UndefOr[Boolean]                                       = js.undefined,
+  visible:               js.UndefOr[Boolean]                                       = js.undefined,
+  warning:               js.UndefOr[Boolean]                                       = js.undefined,
+  override val children: CtorType.ChildrenArgs                                     = Seq.empty
+) extends GenericComponentPC[Message.MessageProps] {
+  override def cprops = Message.props(this)
+  @inline def renderWith =
+    Message.component(Message.props(this))
+  override def withChildren(children: CtorType.ChildrenArgs) =
+    copy(children = children)
+}
+
+object Message {
+  type OnDismiss = (ReactEvent, MessageProps) => Callback
+
+  @js.native
+  @JSImport("semantic-ui-react", "Message")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait MessageProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.undefined
+
+    /** A message can be formatted to attach itself to other content. */
+    var attached: js.UndefOr[Boolean | String] = js.undefined
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.undefined
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.undefined
+
+    /** A message can be formatted to be different colors. */
+    var color: js.UndefOr[suiraw.SemanticCOLORS] = js.undefined
+
+    /** A message can only take up the width of its content. */
+    var compact: js.UndefOr[Boolean] = js.undefined
+
+    /** Shorthand for primary content. */
+    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageContent.MessageContentProps]] = js.undefined
+
+    /** A message may be formatted to display a negative message. Same as `negative`. */
+    var error: js.UndefOr[Boolean] = js.undefined
+
+    /** A message can float above content that it is related to. */
+    var floating: js.UndefOr[Boolean] = js.undefined
+
+    /** Shorthand for MessageHeader. */
+    var header: js.UndefOr[suiraw.SemanticShorthandItem[MessageHeader.MessageHeaderProps]] = js.undefined
+
+    /** A message can be hidden. */
+    var hidden: js.UndefOr[Boolean] = js.undefined
+
+    /** Add an icon by icon name or pass an <Icon /.> */
+    var icon: js.UndefOr[suiraw.SemanticShorthandItem[IconProps]] = js.undefined
+
+    /** A message may be formatted to display information. */
+    var info: js.UndefOr[Boolean] = js.undefined
+
+    /** Array shorthand items for the MessageList. Mutually exclusive with children. */
+    var list: js.UndefOr[suiraw.SemanticShorthandOrArray[MessageList.MessageListProps]] = js.undefined
+
+    /** A message may be formatted to display a negative message. Same as `error`. */
+    var negative: js.UndefOr[Boolean] = js.undefined
+
+    /**
+     * A message that the user can choose to hide.
+     * Called when the user clicks the "x" icon. This also adds the "x" icon.
+     *
+     * @param {SyntheticEvent} event - React's original SyntheticEvent.
+     * @param {object} data - All props.
+     */
+    var onDismiss: js.UndefOr[js.Function2[ReactEvent, MessageProps, Unit]] = js.undefined
+
+    /** A message may be formatted to display a positive message.  Same as `success`. */
+    var positive: js.UndefOr[Boolean] = js.undefined
+
+    /** A message can have different sizes. */
+    var size: js.UndefOr[suiraw.SemanticSIZES] = js.native
+
+    /** A message may be formatted to display a positive message.  Same as `positive`. */
+    var success: js.UndefOr[Boolean] = js.undefined
+
+    /** A message can be set to visible to force itself to be shown. */
+    var visible: js.UndefOr[Boolean] = js.undefined
+
+    /** A message may be formatted to display warning messages. */
+    var warning: js.UndefOr[Boolean] = js.undefined
+  }
+
+  def props(q: Message): MessageProps =
+    rawprops(
+      q.as,
+      q.attached,
+      q.child,
+      q.className,
+      q.clazz,
+      q.color,
+      q.compact,
+      q.content,
+      q.error,
+      q.floating,
+      q.header,
+      q.hidden,
+      q.icon,
+      q.info,
+      q.list,
+      q.negative,
+      q.onDismissE,
+      q.onDismiss,
+      q.positive,
+      q.size,
+      q.success,
+      q.visible,
+      q.warning
+    )
+
+  def rawprops(
+    as:         js.UndefOr[AsC]                                           = js.undefined,
+    attached:   js.UndefOr[MessageAttached]                               = js.undefined,
+    children:   js.UndefOr[VdomNode]                                      = js.undefined,
+    className:  js.UndefOr[String]                                        = js.undefined,
+    clazz:      js.UndefOr[Css]                                           = js.undefined,
+    color:      js.UndefOr[SemanticColor]                                 = js.undefined,
+    compact:    js.UndefOr[Boolean]                                       = js.undefined,
+    content:    js.UndefOr[VdomNode | MessageContent.MessageContentProps] = js.undefined,
+    error:      js.UndefOr[Boolean]                                       = js.undefined,
+    floating:   js.UndefOr[Boolean]                                       = js.undefined,
+    header:     js.UndefOr[VdomNode | MessageHeader.MessageHeaderProps]   = js.undefined,
+    hidden:     js.UndefOr[Boolean]                                       = js.undefined,
+    icon:       js.UndefOr[Icon]                                          = js.undefined,
+    info:       js.UndefOr[Boolean]                                       = js.undefined,
+    list:       js.UndefOr[Seq[VdomNode] | MessageList.MessageListProps]  = js.undefined,
+    negative:   js.UndefOr[Boolean]                                       = js.undefined,
+    onDismissE: js.UndefOr[Message.OnDismiss]                             = js.undefined,
+    onDismiss:  js.UndefOr[Callback]                                      = js.undefined,
+    positive:   js.UndefOr[Boolean]                                       = js.undefined,
+    size:       js.UndefOr[MessageSize]                                   = js.undefined,
+    success:    js.UndefOr[Boolean]                                       = js.undefined,
+    visible:    js.UndefOr[Boolean]                                       = js.undefined,
+    warning:    js.UndefOr[Boolean]                                       = js.undefined
+  ): MessageProps = {
+    val p = (new js.Object).asInstanceOf[MessageProps]
+    p.as        = as.toJs
+    p.attached  = attached.toJs
+    p.children  = children.toJs
+    p.className = (className, clazz).toJs
+    p.color     = color.toJs
+    p.compact   = compact
+    p.content   = content.toRaw
+    p.error     = error
+    p.floating  = floating
+    p.header    = header.toRaw
+    p.hidden    = hidden
+    p.icon      = icon.map(_.props)
+    p.info      = info
+    p.list      = list.toRaw
+    p.negative  = negative
+    p.onDismiss = (onDismissE, onDismiss).toJs
+    p.positive  = positive
+    p.size      = size.toJs
+    p.visible   = visible
+    p.warning   = warning
+    p
+  }
+
+  private val component =
+    JsComponent[MessageProps, Children.Varargs, Null](RawComponent)
+
+  def apply(content: VdomNode*): Message =
+    new Message(children = content)
+}

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageContent.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageContent.scala
@@ -1,0 +1,85 @@
+package react.semanticui.collections.message
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.VdomNode
+import japgolly.scalajs.react.raw.React
+import react.common._
+import react.semanticui._
+import react.semanticui.{ raw => suiraw }
+
+final case class MessageContent(
+  as:        js.UndefOr[AsC]                                           = js.undefined,
+  child:     js.UndefOr[VdomNode]                                      = js.undefined,
+  className: js.UndefOr[String]                                        = js.undefined,
+  clazz:     js.UndefOr[Css]                                           = js.undefined,
+  content:   js.UndefOr[VdomNode | MessageContent.MessageContentProps] = js.undefined,
+  override val children: CtorType.ChildrenArgs                         = Seq.empty
+) extends GenericComponentPC[MessageContent.MessageContentProps] {
+  override def cprops = MessageContent.props(this)
+  @inline def renderWith =
+    MessageContent.component(MessageContent.props(this))
+  override def withChildren(children: CtorType.ChildrenArgs) =
+    copy(children = children)
+}
+
+object MessageContent {
+  @js.native
+  @JSImport("semantic-ui-react", "MessageContent")
+  object RawComponent extends js.Function1[js.Any, js.Any] {
+    def apply(i: js.Any): js.Any = js.native
+  }
+
+  @js.native
+  trait MessageContentProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.undefined
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.undefined
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.undefined
+
+    /** Shorthand for primary content. */
+    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageContent.MessageContentProps]] = js.undefined
+  }
+
+  def props(q: MessageContent): MessageContentProps =
+    rawprops(
+      q.as,
+      q.child,
+      q.className,
+      q.clazz,
+      q.content
+    )
+
+  def rawprops(
+    as:        js.UndefOr[AsC]                                           = js.undefined,
+    children:  js.UndefOr[VdomNode]                                      = js.undefined,
+    className: js.UndefOr[String]                                        = js.undefined,
+    clazz:     js.UndefOr[Css]                                           = js.undefined,
+    content:   js.UndefOr[VdomNode | MessageContent.MessageContentProps] = js.undefined
+  ): MessageContentProps = {
+    val p = (new js.Object).asInstanceOf[MessageContentProps]
+    p.as        = as.toJs
+    p.children  = children.toJs
+    p.className = (className, clazz).toJs
+    p.content   = content.toRaw
+    p
+  }
+
+  private val component =
+    JsComponent[MessageContentProps, Children.Varargs, Null](RawComponent)
+
+  def apply(content: VdomNode*): MessageContent =
+    new MessageContent(children = content)
+}

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageContent.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageContent.scala
@@ -11,12 +11,12 @@ import react.semanticui._
 import react.semanticui.{ raw => suiraw }
 
 final case class MessageContent(
-  as:        js.UndefOr[AsC]                                           = js.undefined,
-  child:     js.UndefOr[VdomNode]                                      = js.undefined,
-  className: js.UndefOr[String]                                        = js.undefined,
-  clazz:     js.UndefOr[Css]                                           = js.undefined,
-  content:   js.UndefOr[VdomNode | MessageContent.MessageContentProps] = js.undefined,
-  override val children: CtorType.ChildrenArgs                         = Seq.empty
+  as:                    js.UndefOr[AsC]                                           = js.undefined,
+  child:                 js.UndefOr[VdomNode]                                      = js.undefined,
+  className:             js.UndefOr[String]                                        = js.undefined,
+  clazz:                 js.UndefOr[Css]                                           = js.undefined,
+  content:               js.UndefOr[VdomNode | MessageContent.MessageContentProps] = js.undefined,
+  override val children: CtorType.ChildrenArgs                                     = Seq.empty
 ) extends GenericComponentPC[MessageContent.MessageContentProps] {
   override def cprops = MessageContent.props(this)
   @inline def renderWith =
@@ -50,7 +50,8 @@ object MessageContent {
     var className: js.UndefOr[String] = js.undefined
 
     /** Shorthand for primary content. */
-    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageContent.MessageContentProps]] = js.undefined
+    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageContent.MessageContentProps]] =
+      js.undefined
   }
 
   def props(q: MessageContent): MessageContentProps =

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageHeader.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageHeader.scala
@@ -11,12 +11,12 @@ import react.semanticui._
 import react.semanticui.{ raw => suiraw }
 
 final case class MessageHeader(
-  as:        js.UndefOr[AsC]                                         = js.undefined,
-  child:     js.UndefOr[VdomNode]                                    = js.undefined,
-  className: js.UndefOr[String]                                      = js.undefined,
-  clazz:     js.UndefOr[Css]                                         = js.undefined,
-  content:   js.UndefOr[VdomNode | MessageHeader.MessageHeaderProps] = js.undefined,
-  override val children: CtorType.ChildrenArgs                       = Seq.empty
+  as:                    js.UndefOr[AsC]                                         = js.undefined,
+  child:                 js.UndefOr[VdomNode]                                    = js.undefined,
+  className:             js.UndefOr[String]                                      = js.undefined,
+  clazz:                 js.UndefOr[Css]                                         = js.undefined,
+  content:               js.UndefOr[VdomNode | MessageHeader.MessageHeaderProps] = js.undefined,
+  override val children: CtorType.ChildrenArgs                                   = Seq.empty
 ) extends GenericComponentPC[MessageHeader.MessageHeaderProps] {
   override def cprops = MessageHeader.props(this)
   @inline def renderWith =
@@ -50,7 +50,8 @@ object MessageHeader {
     var className: js.UndefOr[String] = js.undefined
 
     /** Shorthand for primary content. */
-    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageHeader.MessageHeaderProps]] = js.undefined
+    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageHeader.MessageHeaderProps]] =
+      js.undefined
   }
 
   def props(q: MessageHeader): MessageHeaderProps =

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageHeader.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageHeader.scala
@@ -1,0 +1,85 @@
+package react.semanticui.collections.message
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.VdomNode
+import japgolly.scalajs.react.raw.React
+import react.common._
+import react.semanticui._
+import react.semanticui.{ raw => suiraw }
+
+final case class MessageHeader(
+  as:        js.UndefOr[AsC]                                         = js.undefined,
+  child:     js.UndefOr[VdomNode]                                    = js.undefined,
+  className: js.UndefOr[String]                                      = js.undefined,
+  clazz:     js.UndefOr[Css]                                         = js.undefined,
+  content:   js.UndefOr[VdomNode | MessageHeader.MessageHeaderProps] = js.undefined,
+  override val children: CtorType.ChildrenArgs                       = Seq.empty
+) extends GenericComponentPC[MessageHeader.MessageHeaderProps] {
+  override def cprops = MessageHeader.props(this)
+  @inline def renderWith =
+    MessageHeader.component(MessageHeader.props(this))
+  override def withChildren(children: CtorType.ChildrenArgs) =
+    copy(children = children)
+}
+
+object MessageHeader {
+  @js.native
+  @JSImport("semantic-ui-react", "MessageHeader")
+  object RawComponent extends js.Function1[js.Any, js.Any] {
+    def apply(i: js.Any): js.Any = js.native
+  }
+
+  @js.native
+  trait MessageHeaderProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.undefined
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.undefined
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.undefined
+
+    /** Shorthand for primary content. */
+    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageHeader.MessageHeaderProps]] = js.undefined
+  }
+
+  def props(q: MessageHeader): MessageHeaderProps =
+    rawprops(
+      q.as,
+      q.child,
+      q.className,
+      q.clazz,
+      q.content
+    )
+
+  def rawprops(
+    as:        js.UndefOr[AsC]                                         = js.undefined,
+    children:  js.UndefOr[VdomNode]                                    = js.undefined,
+    className: js.UndefOr[String]                                      = js.undefined,
+    clazz:     js.UndefOr[Css]                                         = js.undefined,
+    content:   js.UndefOr[VdomNode | MessageHeader.MessageHeaderProps] = js.undefined
+  ): MessageHeaderProps = {
+    val p = (new js.Object).asInstanceOf[MessageHeaderProps]
+    p.as        = as.toJs
+    p.children  = children.toJs
+    p.className = (className, clazz).toJs
+    p.content   = content.toRaw
+    p
+  }
+
+  private val component =
+    JsComponent[MessageHeaderProps, Children.Varargs, Null](RawComponent)
+
+  def apply(content: VdomNode*): MessageHeader =
+    new MessageHeader(children = content)
+}

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageItem.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageItem.scala
@@ -1,0 +1,85 @@
+package react.semanticui.collections.message
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.VdomNode
+import japgolly.scalajs.react.raw.React
+import react.common._
+import react.semanticui._
+import react.semanticui.{ raw => suiraw }
+
+final case class MessageItem(
+  as:        js.UndefOr[AsC]                                     = js.undefined,
+  child:     js.UndefOr[VdomNode]                                = js.undefined,
+  className: js.UndefOr[String]                                  = js.undefined,
+  clazz:     js.UndefOr[Css]                                     = js.undefined,
+  content:   js.UndefOr[VdomNode | MessageItem.MessageItemProps] = js.undefined,
+  override val children: CtorType.ChildrenArgs                   = Seq.empty
+) extends GenericComponentPC[MessageItem.MessageItemProps] {
+  override def cprops = MessageItem.props(this)
+  @inline def renderWith =
+    MessageItem.component(MessageItem.props(this))
+  override def withChildren(children: CtorType.ChildrenArgs) =
+    copy(children = children)
+}
+
+object MessageItem {
+  @js.native
+  @JSImport("semantic-ui-react", "MessageItem")
+  object RawComponent extends js.Function1[js.Any, js.Any] {
+    def apply(i: js.Any): js.Any = js.native
+  }
+
+  @js.native
+  trait MessageItemProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.undefined
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.undefined
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.undefined
+
+    /** Shorthand for primary content. */
+    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageItem.MessageItemProps]] = js.undefined
+  }
+
+  def props(q: MessageItem): MessageItemProps =
+    rawprops(
+      q.as,
+      q.child,
+      q.className,
+      q.clazz,
+      q.content
+    )
+
+  def rawprops(
+    as:        js.UndefOr[AsC]                                     = js.undefined,
+    children:  js.UndefOr[VdomNode]                                = js.undefined,
+    className: js.UndefOr[String]                                  = js.undefined,
+    clazz:     js.UndefOr[Css]                                     = js.undefined,
+    content:   js.UndefOr[VdomNode | MessageItem.MessageItemProps] = js.undefined
+  ): MessageItemProps = {
+    val p = (new js.Object).asInstanceOf[MessageItemProps]
+    p.as        = as.toJs
+    p.children  = children.toJs
+    p.className = (className, clazz).toJs
+    p.content   = content.toRaw
+    p
+  }
+
+  private val component =
+    JsComponent[MessageItemProps, Children.Varargs, Null](RawComponent)
+
+  def apply(content: VdomNode*): MessageItem =
+    new MessageItem(children = content)
+}

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageItem.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageItem.scala
@@ -11,12 +11,12 @@ import react.semanticui._
 import react.semanticui.{ raw => suiraw }
 
 final case class MessageItem(
-  as:        js.UndefOr[AsC]                                     = js.undefined,
-  child:     js.UndefOr[VdomNode]                                = js.undefined,
-  className: js.UndefOr[String]                                  = js.undefined,
-  clazz:     js.UndefOr[Css]                                     = js.undefined,
-  content:   js.UndefOr[VdomNode | MessageItem.MessageItemProps] = js.undefined,
-  override val children: CtorType.ChildrenArgs                   = Seq.empty
+  as:                    js.UndefOr[AsC]                                     = js.undefined,
+  child:                 js.UndefOr[VdomNode]                                = js.undefined,
+  className:             js.UndefOr[String]                                  = js.undefined,
+  clazz:                 js.UndefOr[Css]                                     = js.undefined,
+  content:               js.UndefOr[VdomNode | MessageItem.MessageItemProps] = js.undefined,
+  override val children: CtorType.ChildrenArgs                               = Seq.empty
 ) extends GenericComponentPC[MessageItem.MessageItemProps] {
   override def cprops = MessageItem.props(this)
   @inline def renderWith =
@@ -50,7 +50,8 @@ object MessageItem {
     var className: js.UndefOr[String] = js.undefined
 
     /** Shorthand for primary content. */
-    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageItem.MessageItemProps]] = js.undefined
+    var content: js.UndefOr[suiraw.SemanticShorthandItem[MessageItem.MessageItemProps]] =
+      js.undefined
   }
 
   def props(q: MessageItem): MessageItemProps =

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageList.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageList.scala
@@ -1,0 +1,85 @@
+package react.semanticui.collections.message
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.VdomNode
+import japgolly.scalajs.react.raw.React
+import react.common._
+import react.semanticui._
+import react.semanticui.{ raw => suiraw }
+
+final case class MessageList(
+  as:        js.UndefOr[AsC]                                           = js.undefined,
+  child:     js.UndefOr[VdomNode]                                      = js.undefined,
+  className: js.UndefOr[String]                                        = js.undefined,
+  clazz:     js.UndefOr[Css]                                           = js.undefined,
+  items:     js.UndefOr[Seq[VdomNode | MessageItem.MessageItemProps]]  = js.undefined,
+  override val children: CtorType.ChildrenArgs                         = Seq.empty
+) extends GenericComponentPC[MessageList.MessageListProps] {
+  override def cprops = MessageList.props(this)
+  @inline def renderWith =
+    MessageList.component(MessageList.props(this))
+  override def withChildren(children: CtorType.ChildrenArgs) =
+    copy(children = children)
+}
+
+object MessageList {
+  @js.native
+  @JSImport("semantic-ui-react", "MessageList")
+  object RawComponent extends js.Function1[js.Any, js.Any] {
+    def apply(i: js.Any): js.Any = js.native
+  }
+
+  @js.native
+  trait MessageListProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.undefined
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.undefined
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.undefined
+
+    /** Shorthand for primary content. */
+    var items: js.UndefOr[suiraw.SemanticShorthandArray[MessageItem.MessageItemProps]] = js.undefined
+  }
+
+  def props(q: MessageList): MessageListProps =
+    rawprops(
+      q.as,
+      q.child,
+      q.className,
+      q.clazz,
+      q.items
+    )
+
+  def rawprops(
+    as:        js.UndefOr[AsC]                                          = js.undefined,
+    children:  js.UndefOr[VdomNode]                                     = js.undefined,
+    className: js.UndefOr[String]                                       = js.undefined,
+    clazz:     js.UndefOr[Css]                                          = js.undefined,
+    items:     js.UndefOr[Seq[VdomNode | MessageItem.MessageItemProps]] = js.undefined
+  ): MessageListProps = {
+    val p = (new js.Object).asInstanceOf[MessageListProps]
+    p.as        = as.toJs
+    p.children  = children.toJs
+    p.className = (className, clazz).toJs
+    p.items     = items.toRaw
+    p
+  }
+
+  private val component =
+    JsComponent[MessageListProps, Children.Varargs, Null](RawComponent)
+
+  def apply(content: VdomNode*): MessageList =
+    new MessageList(children = content)
+}

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageList.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageList.scala
@@ -11,12 +11,12 @@ import react.semanticui._
 import react.semanticui.{ raw => suiraw }
 
 final case class MessageList(
-  as:        js.UndefOr[AsC]                                           = js.undefined,
-  child:     js.UndefOr[VdomNode]                                      = js.undefined,
-  className: js.UndefOr[String]                                        = js.undefined,
-  clazz:     js.UndefOr[Css]                                           = js.undefined,
-  items:     js.UndefOr[Seq[VdomNode | MessageItem.MessageItemProps]]  = js.undefined,
-  override val children: CtorType.ChildrenArgs                         = Seq.empty
+  as:                    js.UndefOr[AsC]                                          = js.undefined,
+  child:                 js.UndefOr[VdomNode]                                     = js.undefined,
+  className:             js.UndefOr[String]                                       = js.undefined,
+  clazz:                 js.UndefOr[Css]                                          = js.undefined,
+  items:                 js.UndefOr[Seq[VdomNode | MessageItem.MessageItemProps]] = js.undefined,
+  override val children: CtorType.ChildrenArgs                                    = Seq.empty
 ) extends GenericComponentPC[MessageList.MessageListProps] {
   override def cprops = MessageList.props(this)
   @inline def renderWith =
@@ -50,7 +50,8 @@ object MessageList {
     var className: js.UndefOr[String] = js.undefined
 
     /** Shorthand for primary content. */
-    var items: js.UndefOr[suiraw.SemanticShorthandArray[MessageItem.MessageItemProps]] = js.undefined
+    var items: js.UndefOr[suiraw.SemanticShorthandArray[MessageItem.MessageItemProps]] =
+      js.undefined
   }
 
   def props(q: MessageList): MessageListProps =

--- a/facade/src/main/scala/react/semanticui/collections/message/package.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/package.scala
@@ -1,0 +1,31 @@
+package react.semanticui.collections
+
+import react.common.EnumValue
+import react.common.EnumValueB
+
+package message {
+  sealed trait MessageAttached extends Product with Serializable
+  object MessageAttached {
+    implicit val enum: EnumValueB[MessageAttached] = EnumValueB.toLowerCaseStringT(Attached)
+
+    case object Attached extends MessageAttached
+    case object Top extends MessageAttached
+    case object Bottom extends MessageAttached
+  }
+
+  // MessageSize cannot be Medium, thus we define a new enum.
+  sealed trait MessageSize extends Product with Serializable
+  object MessageSize {
+    implicit val enum: EnumValue[MessageSize] = EnumValue.toLowerCaseString
+
+    case object Mini extends MessageSize
+    case object Tiny extends MessageSize
+    case object Small extends MessageSize
+    case object Large extends MessageSize
+    case object Big extends MessageSize
+    case object Huge extends MessageSize
+    case object Massive extends MessageSize
+  }
+}
+
+package object message

--- a/facade/src/main/scala/react/semanticui/modules/checkbox/Checkbox.scala
+++ b/facade/src/main/scala/react/semanticui/modules/checkbox/Checkbox.scala
@@ -44,8 +44,8 @@ final case class Checkbox(
 }
 
 object Checkbox {
-  type Event            = (ReactMouseEvent, js.Object) => Callback
-  private type RawEvent = js.Function2[ReactMouseEvent, js.Object, Unit]
+  type Event            = (ReactMouseEvent, CheckboxProps) => Callback
+  private type RawEvent = js.Function2[ReactMouseEvent, CheckboxProps, Unit]
 
   @js.native
   @JSImport("semantic-ui-react", "Checkbox")

--- a/facade/src/main/scala/react/semanticui/modules/progress/Progress.scala
+++ b/facade/src/main/scala/react/semanticui/modules/progress/Progress.scala
@@ -1,4 +1,4 @@
-package react.semanticui.modules.checkbox
+package react.semanticui.modules.progress
 
 import scala.scalajs.js
 import js.annotation._

--- a/facade/src/main/scala/react/semanticui/package.scala
+++ b/facade/src/main/scala/react/semanticui/package.scala
@@ -3,6 +3,7 @@ package react
 import scala.scalajs.js
 import js.annotation.JSImport
 import js.|
+import js.JSConverters._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.raw.React
 import japgolly.scalajs.react.vdom._
@@ -140,15 +141,22 @@ package object semanticui
 
   implicit class HandItem2ItemUndef[T](val c: js.UndefOr[SemanticShortHandItem[T]]) extends AnyVal {
     def toRaw: js.UndefOr[raw.SemanticShorthandItem[T]] =
-      c.map { d =>
-        (d: Any) match {
-          case o: VdomNode =>
-            o.rawNode.asInstanceOf[raw.SemanticShorthandItem[T]]
-          case f => f.asInstanceOf[T]
-        }
-      }
+      c.map(_.toRaw)
   }
 
+  implicit class HandItemSeq2ArrayUndef[T](val c: js.UndefOr[Seq[SemanticShortHandItem[T]]]) extends AnyVal {
+    def toRaw: js.UndefOr[js.Array[raw.SemanticShorthandItem[T]]] =
+      c.map(_.map(_.toRaw).toJSArray)
+  }
+
+  implicit class HandSeq2OrArrayUndef[T](val c: js.UndefOr[Seq[VdomNode] | T]) extends AnyVal {
+    def toRaw: js.UndefOr[raw.SemanticShorthandOrArray[T]] =
+      (c: Any) match {
+        case s: Seq[_] => s.map(_.asInstanceOf[VdomNode].rawNode).toJSArray.asInstanceOf[raw.SemanticShorthandOrArray[T]]
+        case f         => f.asInstanceOf[T]
+      }
+  }
+  
   def fnToRawOrProps[P <: js.Object](
     c: js.UndefOr[VdomNode | GenericFnComponentPC[P]]
   ): js.UndefOr[raw.SemanticShorthandItem[P]] =
@@ -208,16 +216,18 @@ package object semanticui
   }
 
   private[semanticui] object raw {
-    type SemanticCOLORS             = String
-    type SemanticICONS              = String
-    type SemanticSIZES              = String
-    type SemanticWIDTHS             = String
-    type IconSizeProp               = String
-    type SemanticFLOATS             = String
-    type SemanticTEXTALIGNMENTS     = String
-    type SemanticVERTICALALIGNMENTS = String
-    type SemanticShorthandContent   = React.Node
-    type SemanticShorthandItem[T]   = React.Node | T
+    type SemanticCOLORS               = String
+    type SemanticICONS                = String
+    type SemanticSIZES                = String
+    type SemanticWIDTHS               = String
+    type IconSizeProp                 = String
+    type SemanticFLOATS               = String
+    type SemanticTEXTALIGNMENTS       = String
+    type SemanticVERTICALALIGNMENTS   = String
+    type SemanticShorthandContent     = React.Node
+    type SemanticShorthandItem[T]     = React.Node | T
+    type SemanticShorthandArray[T]    = js.Array[SemanticShorthandItem[T]]
+    type SemanticShorthandOrArray[T]  = js.Array[React.Node] | T
 
     @js.native
     @JSImport("semantic-ui-react", "SemanticCOLORS")

--- a/facade/src/main/scala/react/semanticui/package.scala
+++ b/facade/src/main/scala/react/semanticui/package.scala
@@ -144,7 +144,8 @@ package object semanticui
       c.map(_.toRaw)
   }
 
-  implicit class HandItemSeq2ArrayUndef[T](val c: js.UndefOr[Seq[SemanticShortHandItem[T]]]) extends AnyVal {
+  implicit class HandItemSeq2ArrayUndef[T](val c: js.UndefOr[Seq[SemanticShortHandItem[T]]])
+      extends AnyVal {
     def toRaw: js.UndefOr[js.Array[raw.SemanticShorthandItem[T]]] =
       c.map(_.map(_.toRaw).toJSArray)
   }
@@ -152,11 +153,14 @@ package object semanticui
   implicit class HandSeq2OrArrayUndef[T](val c: js.UndefOr[Seq[VdomNode] | T]) extends AnyVal {
     def toRaw: js.UndefOr[raw.SemanticShorthandOrArray[T]] =
       (c: Any) match {
-        case s: Seq[_] => s.map(_.asInstanceOf[VdomNode].rawNode).toJSArray.asInstanceOf[raw.SemanticShorthandOrArray[T]]
-        case f         => f.asInstanceOf[T]
+        case s: Seq[_] =>
+          s.map(_.asInstanceOf[VdomNode].rawNode)
+            .toJSArray
+            .asInstanceOf[raw.SemanticShorthandOrArray[T]]
+        case f => f.asInstanceOf[T]
       }
   }
-  
+
   def fnToRawOrProps[P <: js.Object](
     c: js.UndefOr[VdomNode | GenericFnComponentPC[P]]
   ): js.UndefOr[raw.SemanticShorthandItem[P]] =
@@ -216,18 +220,18 @@ package object semanticui
   }
 
   private[semanticui] object raw {
-    type SemanticCOLORS               = String
-    type SemanticICONS                = String
-    type SemanticSIZES                = String
-    type SemanticWIDTHS               = String
-    type IconSizeProp                 = String
-    type SemanticFLOATS               = String
-    type SemanticTEXTALIGNMENTS       = String
-    type SemanticVERTICALALIGNMENTS   = String
-    type SemanticShorthandContent     = React.Node
-    type SemanticShorthandItem[T]     = React.Node | T
-    type SemanticShorthandArray[T]    = js.Array[SemanticShorthandItem[T]]
-    type SemanticShorthandOrArray[T]  = js.Array[React.Node] | T
+    type SemanticCOLORS              = String
+    type SemanticICONS               = String
+    type SemanticSIZES               = String
+    type SemanticWIDTHS              = String
+    type IconSizeProp                = String
+    type SemanticFLOATS              = String
+    type SemanticTEXTALIGNMENTS      = String
+    type SemanticVERTICALALIGNMENTS  = String
+    type SemanticShorthandContent    = React.Node
+    type SemanticShorthandItem[T]    = React.Node | T
+    type SemanticShorthandArray[T]   = js.Array[SemanticShorthandItem[T]]
+    type SemanticShorthandOrArray[T] = js.Array[React.Node] | T
 
     @js.native
     @JSImport("semantic-ui-react", "SemanticCOLORS")

--- a/facade/src/test/scala/react/semanticui/collections/message/MessageTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/message/MessageTests.scala
@@ -1,0 +1,87 @@
+package react.semanticui.collections.message
+
+import utest._
+import japgolly.scalajs.react.test._
+import japgolly.scalajs.react.vdom.html_<^._
+
+object MessageTests extends TestSuite {
+  val tests = Tests {
+    test("render") {
+      val message = Message()
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        message.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div class="ui message"></div>""")
+      }
+    }
+
+    test("header") {
+      val message = Message(
+        MessageHeader()
+      )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        message.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div class="ui message"><div class="header"></div></div>""")
+      }
+    }
+
+    test("headerShorthand") {
+      val message = Message(
+        header = "": VdomNode
+      )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        message.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div class="ui message"><div class="content"><div class="header"></div></div></div>""")
+      }
+    }
+
+    test("content") {
+      val message = Message(
+        MessageContent()
+      )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        message.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div class="ui message"><div class="content"></div></div>""")
+      }
+    }
+
+    test("contentShorthand") {
+      val message = Message(
+        content = "*": VdomNode
+      )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        message.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div class="ui message">*</div>""")
+      }
+    }
+
+    test("list") {
+      val message = Message(
+        MessageList(
+          MessageItem(""),
+          MessageItem("")
+        )
+      )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        message.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div class="ui message"><ul class="list"><li class="content"></li><li class="content"></li></ul></div>""")
+      }
+    }
+
+    test("listShorthand") {
+      val message = Message(
+        list = List[VdomNode]("", "")
+      )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        message.renderIntoDOM(mountNode)
+        val html = mountNode.innerHTML
+        assert(html == """<div class="ui message"><div class="content"><ul class="list"><li class="content"></li><li class="content"></li></ul></div></div>""")
+      }
+    }
+  } 
+}

--- a/facade/src/test/scala/react/semanticui/collections/message/MessageTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/message/MessageTests.scala
@@ -33,7 +33,9 @@ object MessageTests extends TestSuite {
       ReactTestUtils.withNewBodyElement { mountNode =>
         message.renderIntoDOM(mountNode)
         val html = mountNode.innerHTML
-        assert(html == """<div class="ui message"><div class="content"><div class="header"></div></div></div>""")
+        assert(
+          html == """<div class="ui message"><div class="content"><div class="header"></div></div></div>"""
+        )
       }
     }
 
@@ -69,7 +71,9 @@ object MessageTests extends TestSuite {
       ReactTestUtils.withNewBodyElement { mountNode =>
         message.renderIntoDOM(mountNode)
         val html = mountNode.innerHTML
-        assert(html == """<div class="ui message"><ul class="list"><li class="content"></li><li class="content"></li></ul></div>""")
+        assert(
+          html == """<div class="ui message"><ul class="list"><li class="content"></li><li class="content"></li></ul></div>"""
+        )
       }
     }
 
@@ -80,8 +84,10 @@ object MessageTests extends TestSuite {
       ReactTestUtils.withNewBodyElement { mountNode =>
         message.renderIntoDOM(mountNode)
         val html = mountNode.innerHTML
-        assert(html == """<div class="ui message"><div class="content"><ul class="list"><li class="content"></li><li class="content"></li></ul></div></div>""")
+        assert(
+          html == """<div class="ui message"><div class="content"><ul class="list"><li class="content"></li><li class="content"></li></ul></div></div>"""
+        )
       }
     }
-  } 
+  }
 }

--- a/facade/src/test/scala/react/semanticui/modules/progress/ProgressTests.scala
+++ b/facade/src/test/scala/react/semanticui/modules/progress/ProgressTests.scala
@@ -1,4 +1,4 @@
-package react.semanticui.modules.checkbox
+package react.semanticui.modules.progress
 
 import utest._
 import japgolly.scalajs.react.test._


### PR DESCRIPTION
- Add `Message`, `MessageContent`, `MessageHeader`, `MessageList` and `MessageItem` components.
- Specify event type for `Checkbox` and `Radio` callbacks.
- Fix progress package.
