### PR TITLE
Omit undefined properties from props objects

### DIFF
--- a/facade/src/main/scala/react/semanticui/addons/confirm/Confirm.scala
+++ b/facade/src/main/scala/react/semanticui/addons/confirm/Confirm.scala
@@ -157,29 +157,31 @@ object Confirm {
     trigger:              js.UndefOr[VdomNode]                 = js.undefined
   ): ConfirmProps = {
     val p = as.toJsObject[ConfirmProps]
-    p.as                   = as.toJs
-    p.basic                = basic
-    p.cancelButton         = cancelButton.toJs
-    p.centered             = centered
-    p.className            = (className, clazz).toJs
-    p.closeIcon            = closeIcon.map(_.props)
-    p.closeOnDimmerClick   = closeOnDimmerClick
-    p.closeOnDocumentClick = closeOnDocumentClick
-    p.confirmButton        = confirmButton.toJs
-    p.content              = content.toJs
-    p.defaultOpen          = defaultOpen
-    p.dimmer               = dimmer.toJs
-    p.eventPool            = eventPool
-    p.header               = header.toJs
-    p.onActionClick        = (onActionClickE, onActionClick).toJs
-    p.onCancel             = (onCancelE, onCancel).toJs
-    p.onClose              = (onCloseE, onClose).toJs
-    p.onConfirm            = (onConfirmE, onConfirm).toJs
-    p.onMount              = (onMountE, onMount).toJs.map(f => (_, p: Modal.ModalProps) => f(p))
-    p.open                 = open
-    p.size                 = size.toJs
-    p.style                = style.map(_.toJsObject)
-    p.trigger              = trigger.toJs
+    as.toJs.foreach(v => p.as                                         = v)
+    basic.foreach(v => p.basic                                        = v)
+    cancelButton.toJs.foreach(v => p.cancelButton                     = v)
+    centered.foreach(v => p.centered                                  = v)
+    (className, clazz).toJs.foreach(v => p.className                  = v)
+    closeIcon.map(_.props).foreach(v => p.closeIcon                   = v)
+    closeOnDimmerClick.foreach(v => p.closeOnDimmerClick              = v)
+    closeOnDocumentClick.foreach(v => p.closeOnDocumentClick          = v)
+    confirmButton.toJs.foreach(v => p.confirmButton                   = v)
+    content.toJs.foreach(v => p.content                               = v)
+    defaultOpen.foreach(v => p.defaultOpen                            = v)
+    dimmer.toJs.foreach(v => p.dimmer                                 = v)
+    eventPool.foreach(v => p.eventPool                                = v)
+    header.toJs.foreach(v => p.header                                 = v)
+    (onActionClickE, onActionClick).toJs.foreach(v => p.onActionClick = v)
+    (onCancelE, onCancel).toJs.foreach(v => p.onCancel                = v)
+    (onCloseE, onClose).toJs.foreach(v => p.onClose                   = v)
+    (onConfirmE, onConfirm).toJs.foreach(v => p.onConfirm             = v)
+    (onMountE, onMount).toJs
+      .map[Modal.RawOnMount](f => (_, p: Modal.ModalProps) => f(p))
+      .foreach(v => p.onMount                    = v)
+    open.foreach(v => p.open                     = v)
+    size.toJs.foreach(v => p.size                = v)
+    style.map(_.toJsObject).foreach(v => p.style = v)
+    trigger.toJs.foreach(v => p.trigger          = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/addons/portal/Portal.scala
+++ b/facade/src/main/scala/react/semanticui/addons/portal/Portal.scala
@@ -206,25 +206,25 @@ object Portal {
     trigger:                  js.UndefOr[VdomNode]         = js.undefined
   ): PortalProps = {
     val p = (new js.Object).asInstanceOf[PortalProps]
-    p.closeOnDocumentClick     = closeOnDocumentClick
-    p.closeOnEscape            = closeOnEscape
-    p.closeOnPortalMouseLeave  = closeOnPortalMouseLeave
-    p.closeOnTriggerBlur       = closeOnTriggerBlur
-    p.closeOnTriggerClick      = closeOnTriggerClick
-    p.closeOnTriggerMouseLeave = closeOnTriggerMouseLeave
-    p.defaultOpen              = defaultOpen
-    p.eventPool                = eventPool
-    p.mouseEnterDelay          = mouseEnterDelay
-    p.mouseLeaveDelay          = mouseLeaveDelay
-    p.onClose                  = (onCloseE, onClose).toJs
-    p.onMount                  = (onMountE, onMount).toJs
-    p.onOpen                   = (onOpenE, onOpen).toJs
-    p.onUnmount                = (onUnmountE, onUnmount).toJs
-    p.open                     = open
-    p.openOnTriggerClick       = openOnTriggerClick
-    p.openOnTriggerFocus       = openOnTriggerFocus
-    p.openOnTriggerMouseEnter  = openOnTriggerMouseEnter
-    p.trigger                  = trigger.toJs
+    closeOnDocumentClick.foreach(v => p.closeOnDocumentClick         = v)
+    closeOnEscape.foreach(v => p.closeOnEscape                       = v)
+    closeOnPortalMouseLeave.foreach(v => p.closeOnPortalMouseLeave   = v)
+    closeOnTriggerBlur.foreach(v => p.closeOnTriggerBlur             = v)
+    closeOnTriggerClick.foreach(v => p.closeOnTriggerClick           = v)
+    closeOnTriggerMouseLeave.foreach(v => p.closeOnTriggerMouseLeave = v)
+    defaultOpen.foreach(v => p.defaultOpen                           = v)
+    eventPool.foreach(v => p.eventPool                               = v)
+    mouseEnterDelay.foreach(v => p.mouseEnterDelay                   = v)
+    mouseLeaveDelay.foreach(v => p.mouseLeaveDelay                   = v)
+    (onCloseE, onClose).toJs.foreach(v => p.onClose                  = v)
+    (onMountE, onMount).toJs.foreach(v => p.onMount                  = v)
+    (onOpenE, onOpen).toJs.foreach(v => p.onOpen                     = v)
+    (onUnmountE, onUnmount).toJs.foreach(v => p.onUnmount            = v)
+    open.foreach(v => p.open                                         = v)
+    openOnTriggerClick.foreach(v => p.openOnTriggerClick             = v)
+    openOnTriggerFocus.foreach(v => p.openOnTriggerFocus             = v)
+    openOnTriggerMouseEnter.foreach(v => p.openOnTriggerMouseEnter   = v)
+    trigger.toJs.foreach(v => p.trigger                              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/addons/portal/PortalInner.scala
+++ b/facade/src/main/scala/react/semanticui/addons/portal/PortalInner.scala
@@ -83,8 +83,8 @@ object PortalInner {
   ): PortalInnerProps = {
     val p = (new js.Object).asInstanceOf[PortalInnerProps]
     // p.innerRef = innerRef
-    p.onMount   = (onMountE, onMount).toJs
-    p.onUnmount = (onUnmountE, onUnmount).toJs
+    (onMountE, onMount).toJs.foreach(v => p.onMount       = v)
+    (onUnmountE, onUnmount).toJs.foreach(v => p.onUnmount = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/addons/radio/Radio.scala
+++ b/facade/src/main/scala/react/semanticui/addons/radio/Radio.scala
@@ -212,28 +212,28 @@ object Radio {
     value:                js.UndefOr[String | JsNumber] = js.undefined
   ): RadioProps = {
     val p = as.toJsObject[RadioProps]
-    p.as                   = as.toJs
-    p.checked              = checked
-    p.className            = (className, clazz).toJs
-    p.defaultChecked       = defaultChecked
-    p.defaultIndeterminate = defaultIndeterminate
-    p.disabled             = disabled
-    p.fitted               = fitted
-    p.id                   = id
-    p.indeterminate        = indeterminate
-    p.label                = label
-    p.name                 = name
-    p.onChange             = (onChangeE, onChange).toJs
-    p.onClick              = (onClickE, onClick).toJs
-    p.onMouseDown          = (onMouseDownE, onMouseDown).toJs
-    p.onMouseUp            = (onMouseUpE, onMouseUp).toJs
-    p.radio                = radio
-    p.readOnly             = readOnly
-    p.slider               = slider
-    p.tabIndex             = tabIndex
-    p.toggle               = toggle
-    p.`type`               = `type`.toJs
-    p.value                = value
+    as.toJs.foreach(v => p.as                                   = v)
+    checked.foreach(v => p.checked                              = v)
+    (className, clazz).toJs.foreach(v => p.className            = v)
+    defaultChecked.foreach(v => p.defaultChecked                = v)
+    defaultIndeterminate.foreach(v => p.defaultIndeterminate    = v)
+    disabled.foreach(v => p.disabled                            = v)
+    fitted.foreach(v => p.fitted                                = v)
+    id.foreach(v => p.id                                        = v)
+    indeterminate.foreach(v => p.indeterminate                  = v)
+    label.foreach(v => p.label                                  = v)
+    name.foreach(v => p.name                                    = v)
+    (onChangeE, onChange).toJs.foreach(v => p.onChange          = v)
+    (onClickE, onClick).toJs.foreach(v => p.onClick             = v)
+    (onMouseDownE, onMouseDown).toJs.foreach(v => p.onMouseDown = v)
+    (onMouseUpE, onMouseUp).toJs.foreach(v => p.onMouseUp       = v)
+    radio.foreach(v => p.radio                                  = v)
+    readOnly.foreach(v => p.readOnly                            = v)
+    slider.foreach(v => p.slider                                = v)
+    tabIndex.foreach(v => p.tabIndex                            = v)
+    toggle.foreach(v => p.toggle                                = v)
+    p.`type` = `type`.toJs
+    value.foreach(v => p.value = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/addons/select/Select.scala
+++ b/facade/src/main/scala/react/semanticui/addons/select/Select.scala
@@ -11,6 +11,7 @@ import js.JSConverters._
 import react.common._
 import react.common.style._
 import react.semanticui._
+import react.semanticui.raw._
 import react.semanticui.elements.icon.Icon
 import react.semanticui.elements.label.Label
 import react.semanticui.modules.dropdown._
@@ -18,7 +19,7 @@ import react.semanticui.modules.dropdown.Dropdown._
 
 final case class Select(
   as:                     js.UndefOr[AsC] = js.undefined,
-  additionLabel:          js.UndefOr[Dropdown.AdditionLabel] = js.undefined,
+  additionLabel:          js.UndefOr[AdditionLabel] = js.undefined,
   additionPosition:       js.UndefOr[AdditionPosition] = js.undefined,
   allowAdditions:         js.UndefOr[Boolean] = js.undefined,
   basic:                  js.UndefOr[Boolean] = js.undefined,
@@ -35,7 +36,7 @@ final case class Select(
   defaultSearchQuery:     js.UndefOr[String] = js.undefined,
   defaultSelectedLabel:   js.UndefOr[JsNumber | String] = js.undefined,
   defaultUpward:          js.UndefOr[Boolean] = js.undefined,
-  defaultValue:           js.UndefOr[Dropdown.Value] = js.undefined,
+  defaultValue:           js.UndefOr[Value] = js.undefined,
   direction:              js.UndefOr[Direction] = js.undefined,
   disabled:               js.UndefOr[Boolean] = js.undefined,
   error:                  js.UndefOr[Boolean] = js.undefined,
@@ -51,31 +52,32 @@ final case class Select(
   minCharacters:          js.UndefOr[JsNumber] = js.undefined,
   multiple:               js.UndefOr[Boolean] = js.undefined,
   noResultsMessage:       js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
-  onAddItem:              js.UndefOr[Dropdown.OnAddItem] = js.undefined,
-  onBlurE:                js.UndefOr[Dropdown.OnBlur] = js.undefined,
+  onAddItem:              js.UndefOr[OnAddItem] = js.undefined,
+  onBlurE:                js.UndefOr[OnBlur] = js.undefined,
   onBlur:                 js.UndefOr[Callback] = js.undefined,
-  onClickE:               js.UndefOr[Dropdown.OnClick] = js.undefined,
+  onClickE:               js.UndefOr[OnClick] = js.undefined,
   onClick:                js.UndefOr[Callback] = js.undefined,
-  onChange:               js.UndefOr[Dropdown.OnChange] = js.undefined,
-  onCloseE:               js.UndefOr[Dropdown.OnClose] = js.undefined,
+  onChangeE:              js.UndefOr[OnChangeE] = js.undefined,
+  onChange:               js.UndefOr[OnChange] = js.undefined,
+  onCloseE:               js.UndefOr[OnClose] = js.undefined,
   onClose:                js.UndefOr[Callback] = js.undefined,
-  onFocusE:               js.UndefOr[Dropdown.OnFocus] = js.undefined,
+  onFocusE:               js.UndefOr[OnFocus] = js.undefined,
   onFocus:                js.UndefOr[Callback] = js.undefined,
-  onLabelClickE:          js.UndefOr[Dropdown.OnLabelClick] = js.undefined,
+  onLabelClickE:          js.UndefOr[OnLabelClick] = js.undefined,
   onLabelClick:           js.UndefOr[Callback] = js.undefined,
-  onMouseDownE:           js.UndefOr[Dropdown.OnMouseDown] = js.undefined,
+  onMouseDownE:           js.UndefOr[OnMouseDown] = js.undefined,
   onMouseDown:            js.UndefOr[Callback] = js.undefined,
-  onOpenE:                js.UndefOr[Dropdown.OnOpen] = js.undefined,
+  onOpenE:                js.UndefOr[OnOpen] = js.undefined,
   onOpen:                 js.UndefOr[Callback] = js.undefined,
-  onSearchChangeE:        js.UndefOr[Dropdown.OnSearchChangeE] = js.undefined,
-  onSearchChange:         js.UndefOr[Dropdown.OnSearchChange] = js.undefined,
+  onSearchChangeE:        js.UndefOr[OnSearchChangeE] = js.undefined,
+  onSearchChange:         js.UndefOr[OnSearchChange] = js.undefined,
   open:                   js.UndefOr[Boolean] = js.undefined,
   openOnFocus:            js.UndefOr[Boolean] = js.undefined,
   placeholder:            js.UndefOr[String] = js.undefined,
   pointing:               js.UndefOr[Pointing] = js.undefined,
-  renderLabel:            js.UndefOr[Dropdown.RenderLabel] = js.undefined,
+  renderLabel:            js.UndefOr[RenderLabel] = js.undefined,
   scrolling:              js.UndefOr[Boolean] = js.undefined,
-  search:                 js.UndefOr[Boolean | Dropdown.SearchFunction] = js.undefined,
+  search:                 js.UndefOr[Boolean | SearchFunction] = js.undefined,
   searchInput:            js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
   searchQuery:            js.UndefOr[String] = js.undefined,
   selectOnBlur:           js.UndefOr[Boolean] = js.undefined,
@@ -86,11 +88,11 @@ final case class Select(
   tabIndex:               js.UndefOr[String | JsNumber] = js.undefined,
   text:                   js.UndefOr[String] = js.undefined,
   trigger:                js.UndefOr[VdomNode] = js.undefined,
-  value:                  js.UndefOr[Dropdown.Value] = js.undefined,
+  value:                  js.UndefOr[Value] = js.undefined,
   upward:                 js.UndefOr[Boolean] = js.undefined,
   wrapSelection:          js.UndefOr[Boolean] = js.undefined,
   override val modifiers: Seq[TagMod] = Seq.empty,
-  options:                Seq[DropdownItem]
+  options:                Seq[Select.SelectItem]
 ) extends GenericComponentPA[Select.SelectProps, Select] {
   override protected def cprops    = Select.props(this)
   override protected val component = Select.component
@@ -107,7 +109,7 @@ object Select {
   }
 
   @js.native
-  trait SelectProps extends Dropdown.DropdownProps {}
+  trait SelectProps extends DropdownProps {}
 
   def props(q: Select): SelectProps =
     rawprops(
@@ -150,6 +152,7 @@ object Select {
       q.onBlur,
       q.onClickE,
       q.onClick,
+      q.onChangeE,
       q.onChange,
       q.onCloseE,
       q.onClose,
@@ -226,6 +229,7 @@ object Select {
     onBlur:               js.UndefOr[Callback]                 = js.undefined,
     onClickE:             js.UndefOr[OnClick]                  = js.undefined,
     onClick:              js.UndefOr[Callback]                 = js.undefined,
+    onChangeE:            js.UndefOr[OnChangeE]                = js.undefined,
     onChange:             js.UndefOr[OnChange]                 = js.undefined,
     onCloseE:             js.UndefOr[OnClose]                  = js.undefined,
     onClose:              js.UndefOr[Callback]                 = js.undefined,
@@ -241,7 +245,7 @@ object Select {
     onSearchChange:       js.UndefOr[OnSearchChange]           = js.undefined,
     open:                 js.UndefOr[Boolean]                  = js.undefined,
     openOnFocus:          js.UndefOr[Boolean]                  = js.undefined,
-    options:              js.UndefOr[Seq[DropdownItem]]        = js.undefined,
+    options:              js.UndefOr[Seq[SelectItem]]          = js.undefined,
     placeholder:          js.UndefOr[String]                   = js.undefined,
     pointing:             js.UndefOr[Pointing]                 = js.undefined,
     renderLabel:          js.UndefOr[RenderLabel]              = js.undefined,
@@ -262,96 +266,108 @@ object Select {
     wrapSelection:        js.UndefOr[Boolean]                  = js.undefined
   ): SelectProps = {
     val p = as.toJsObject[SelectProps]
-    p.as = as.toJs
-    p.additionLabel = additionLabel.map {
-      (_: Any) match {
-        case b: String => b
-        case b: Byte   => b
-        case b: Short  => b
-        case b: Int    => b
-        case b: Float  => b
-        case b: Double => b
-        case b: VdomNode =>
-          b.rawNode.asInstanceOf[Dropdown.RawAdditionLabel]
+    as.toJs.foreach(v => p.as = v)
+    additionLabel
+      .map[JsNumber | String | SemanticShorthandContent] {
+        (_: Any) match {
+          case b: String => b
+          case b: Byte   => b
+          case b: Short  => b
+          case b: Int    => b
+          case b: Float  => b
+          case b: Double => b
+          case b: VdomNode =>
+            b.rawNode.asInstanceOf[RawAdditionLabel]
+        }
       }
-    }
-    p.additionPosition     = additionPosition.toJs
-    p.allowAdditions       = allowAdditions
-    p.basic                = basic
-    p.button               = button
-    p.className            = (className, clazz).toJs
-    p.clearable            = clearable
-    p.closeOnBlur          = closeOnBlur
-    p.closeOnEscape        = closeOnEscape
-    p.closeOnChange        = closeOnChange
-    p.compact              = compact
-    p.deburr               = deburr
-    p.defaultOpen          = defaultOpen
-    p.defaultSearchQuery   = defaultSearchQuery
-    p.defaultSelectedLabel = defaultSelectedLabel
-    p.defaultUpward        = defaultUpward
-    p.defaultValue         = defaultValue
-    p.direction            = direction.toJs
-    p.disabled             = disabled
-    p.error                = error
-    p.floating             = floating
-    p.fluid                = fluid
-    p.header               = header.toJs
-    p.icon                 = icon.toJs
-    p.inline               = inline
-    p.item                 = item
-    p.labeled              = labeled
-    p.lazyLoad             = lazyLoad
-    p.loading              = loading
-    p.minCharacters        = minCharacters
-    p.multiple             = multiple
-    p.noResultsMessage     = noResultsMessage.toJs
-    p.onAddItem            = onAddItem.toJs
-    p.onBlur               = (onBlurE, onBlur).toJs
-    p.onChange             = onChange.toJs
-    p.onClick              = (onClickE, onClick).toJs
-    p.onClose              = (onCloseE, onClose).toJs
-    p.onFocus              = (onFocusE, onFocus).toJs
-    p.onLabelClick         = (onLabelClickE, onLabelClick).toJs
-    p.onMouseDown          = (onMouseDownE, onMouseDown).toJs
-    p.onOpen               = (onOpenE, onOpen).toJs
-    p.onSearchChange = onSearchChangeE.toJs.orElse(
-      onSearchChange.map(t => (_: ReactEvent, b: DropdownOnSearchChangeData) => t(b).runNow)
-    )
-    p.onAddItem   = onAddItem.toJs
-    p.open        = open
-    p.openOnFocus = openOnFocus
-    p.options     = options.map(_.map(_.props).toJSArray)
-    p.placeholder = placeholder
-    p.pointing    = pointing.toJs
-    p.renderLabel = renderLabel.map {
-      b => (item: DropdownItem.DropdownItemProps, index: Int, defaultProps: Label.LabelProps) =>
-        b(item, index, defaultProps).runNow
-    }
-    p.scrolling = scrolling
-    p.search = search.map {
-      (_: Any) match {
-        case b: Boolean => b
-        case b =>
-          val sf = b.asInstanceOf[SearchFunction]
-          val rsf: RawSearchFunction = (l: js.Array[DropdownItem.DropdownItemProps], s: String) =>
-            sf(l.toList, s).runNow.toJSArray
-          rsf
+      .foreach(v => p.additionLabel                          = v)
+    additionPosition.toJs.foreach(v => p.additionPosition    = v)
+    allowAdditions.foreach(v => p.allowAdditions             = v)
+    basic.foreach(v => p.basic                               = v)
+    button.foreach(v => p.button                             = v)
+    (className, clazz).toJs.foreach(v => p.className         = v)
+    clearable.foreach(v => p.clearable                       = v)
+    closeOnBlur.foreach(v => p.closeOnBlur                   = v)
+    closeOnEscape.foreach(v => p.closeOnEscape               = v)
+    closeOnChange.foreach(v => p.closeOnChange               = v)
+    compact.foreach(v => p.compact                           = v)
+    deburr.foreach(v => p.deburr                             = v)
+    defaultOpen.foreach(v => p.defaultOpen                   = v)
+    defaultSearchQuery.foreach(v => p.defaultSearchQuery     = v)
+    defaultSelectedLabel.foreach(v => p.defaultSelectedLabel = v)
+    defaultUpward.foreach(v => p.defaultUpward               = v)
+    defaultValue.foreach(v => p.defaultValue                 = v)
+    direction.toJs.foreach(v => p.direction                  = v)
+    disabled.foreach(v => p.disabled                         = v)
+    error.foreach(v => p.error                               = v)
+    floating.foreach(v => p.floating                         = v)
+    fluid.foreach(v => p.fluid                               = v)
+    header.toJs.foreach(v => p.header                        = v)
+    icon.toJs.foreach(v => p.icon                            = v)
+    inline.foreach(v => p.inline                             = v)
+    item.foreach(v => p.item                                 = v)
+    labeled.foreach(v => p.labeled                           = v)
+    lazyLoad.foreach(v => p.lazyLoad                         = v)
+    loading.foreach(v => p.loading                           = v)
+    minCharacters.foreach(v => p.minCharacters               = v)
+    multiple.foreach(v => p.multiple                         = v)
+    noResultsMessage.toJs.foreach(v => p.noResultsMessage    = v)
+    onAddItem.toJs.foreach(v => p.onAddItem                  = v)
+    (onBlurE, onBlur).toJs.foreach(v => p.onBlur             = v)
+    onChangeE.toJs
+      .orElse[RawOnChange](
+        onChange.map(t => (_: ReactEvent, b: DropdownProps) => t(b).runNow)
+      )
+      .foreach(v => p.onChange                                     = v)
+    (onClickE, onClick).toJs.foreach(v => p.onClick                = v)
+    (onCloseE, onClose).toJs.foreach(v => p.onClose                = v)
+    (onFocusE, onFocus).toJs.foreach(v => p.onFocus                = v)
+    (onLabelClickE, onLabelClick).toJs.foreach(v => p.onLabelClick = v)
+    (onMouseDownE, onMouseDown).toJs.foreach(v => p.onMouseDown    = v)
+    (onOpenE, onOpen).toJs.foreach(v => p.onOpen                   = v)
+    onSearchChangeE.toJs
+      .orElse[RawOnSearchChange](
+        onSearchChange.map(t => (_: ReactEvent, b: DropdownOnSearchChangeData) => t(b).runNow)
+      )
+      .foreach(v => p.onSearchChange                             = v)
+    onAddItem.toJs.foreach(v => p.onAddItem                      = v)
+    open.foreach(v => p.open                                     = v)
+    openOnFocus.foreach(v => p.openOnFocus                       = v)
+    options.map(_.map(_.props).toJSArray).foreach(v => p.options = v)
+    placeholder.foreach(v => p.placeholder                       = v)
+    pointing.toJs.foreach(v => p.pointing                        = v)
+    renderLabel
+      .map[RawRenderLabel] {
+        b => (item: DropdownItem.DropdownItemProps, index: Int, defaultProps: Label.LabelProps) =>
+          b(item, index, defaultProps).runNow
       }
-    }
-    p.searchInput        = searchInput.toJs
-    p.searchQuery        = searchQuery
-    p.selectOnBlur       = selectOnBlur
-    p.selectOnNavigation = selectOnNavigation
-    p.selectedLabel      = selectedLabel
-    p.selection          = selection
-    p.simple             = simple
-    p.tabIndex           = tabIndex
-    p.text               = text
-    p.trigger            = trigger.toJs
-    p.value              = value
-    p.upward             = upward
-    p.wrapSelection      = wrapSelection
+      .foreach(v => p.renderLabel      = v)
+    scrolling.foreach(v => p.scrolling = v)
+    search
+      .map[Boolean | RawSearchFunction] {
+        (_: Any) match {
+          case b: Boolean => b
+          case b =>
+            val sf = b.asInstanceOf[SearchFunction]
+            val rsf: RawSearchFunction = (l: js.Array[DropdownItem.DropdownItemProps], s: String) =>
+              sf(l.toList, s).runNow.toJSArray
+            rsf
+        }
+      }
+      .foreach(v => p.search                             = v)
+    searchInput.toJs.foreach(v => p.searchInput          = v)
+    searchQuery.foreach(v => p.searchQuery               = v)
+    selectOnBlur.foreach(v => p.selectOnBlur             = v)
+    selectOnNavigation.foreach(v => p.selectOnNavigation = v)
+    selectedLabel.foreach(v => p.selectedLabel           = v)
+    selection.foreach(v => p.selection                   = v)
+    simple.foreach(v => p.simple                         = v)
+    tabIndex.foreach(v => p.tabIndex                     = v)
+    text.foreach(v => p.text                             = v)
+    trigger.toJs.foreach(v => p.trigger                  = v)
+    value.foreach(v => p.value                           = v)
+    upward.foreach(v => p.upward                         = v)
+    wrapSelection.foreach(v => p.wrapSelection           = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/form/Form.scala
+++ b/facade/src/main/scala/react/semanticui/collections/form/Form.scala
@@ -131,19 +131,19 @@ object Form {
     widths:      js.UndefOr[FormWidths]     = js.undefined
   ): FormProps = {
     val p = as.toJsObject[FormProps]
-    p.as          = as.toJs
-    p.action      = action
-    p.className   = (className, clazz).toJs
-    p.error       = error
-    p.inverted    = inverted
-    p.loading     = loading
-    p.onSubmit    = (onSubmitE, onSubmit).toJs
-    p.reply       = reply
-    p.size        = size.toJs
-    p.success     = success
-    p.unstackable = unstackable
-    p.warning     = warning
-    p.widths      = widths.toJs
+    as.toJs.foreach(v => p.as                          = v)
+    action.foreach(v => p.action                       = v)
+    (className, clazz).toJs.foreach(v => p.className   = v)
+    error.foreach(v => p.error                         = v)
+    inverted.foreach(v => p.inverted                   = v)
+    loading.foreach(v => p.loading                     = v)
+    (onSubmitE, onSubmit).toJs.foreach(v => p.onSubmit = v)
+    reply.foreach(v => p.reply                         = v)
+    size.toJs.foreach(v => p.size                      = v)
+    success.foreach(v => p.success                     = v)
+    unstackable.foreach(v => p.unstackable             = v)
+    warning.foreach(v => p.warning                     = v)
+    widths.toJs.foreach(v => p.widths                  = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/form/FormField.scala
+++ b/facade/src/main/scala/react/semanticui/collections/form/FormField.scala
@@ -120,17 +120,17 @@ object FormField {
     width:     js.UndefOr[SemanticWidth]        = js.undefined
   ): FormFieldProps = {
     val p = as.toJsObject[FormFieldProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
-    p.control   = control
-    p.disabled  = disabled
-    p.error     = error.toJs
-    p.inline    = inline
-    p.label     = label.toJs
-    p.required  = required
-    p.`type`    = tpe
-    p.width     = width.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    control.foreach(v => p.control                   = v)
+    disabled.foreach(v => p.disabled                 = v)
+    error.toJs.foreach(v => p.error                  = v)
+    inline.foreach(v => p.inline                     = v)
+    label.toJs.foreach(v => p.label                  = v)
+    required.foreach(v => p.required                 = v)
+    p.`type` = tpe
+    width.toJs.foreach(v => p.width = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/form/FormGroup.scala
+++ b/facade/src/main/scala/react/semanticui/collections/form/FormGroup.scala
@@ -90,18 +90,20 @@ object FormGroup {
     widths:      js.UndefOr[SemanticWidth | FormWidths] = js.undefined
   ): FormGroupProps = {
     val p = as.toJsObject[FormGroupProps]
-    p.as          = as.toJs
-    p.className   = (className, clazz).toJs
-    p.content     = content.toJs
-    p.grouped     = grouped
-    p.inline      = inline
-    p.unstackable = unstackable
-    p.widths = widths.map {
-      (_: Any) match {
-        case w: FormWidths => w.toJs
-        case w             => w.asInstanceOf[SemanticWidth].toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    grouped.foreach(v => p.grouped                   = v)
+    inline.foreach(v => p.inline                     = v)
+    unstackable.foreach(v => p.unstackable           = v)
+    widths
+      .map {
+        (_: Any) match {
+          case w: FormWidths => w.toJs
+          case w             => w.asInstanceOf[SemanticWidth].toJs
+        }
       }
-    }
+      .foreach(v => p.widths = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/grid/Grid.scala
+++ b/facade/src/main/scala/react/semanticui/collections/grid/Grid.scala
@@ -144,22 +144,22 @@ object Grid {
     verticalAlign: js.UndefOr[SemanticVerticalAlignment] = js.undefined
   ): GridProps = {
     val p = as.toJsObject[GridProps]
-    p.as            = as.toJs
-    p.celled        = celled.toJs
-    p.centered      = centered
-    p.className     = (className, clazz).toJs
-    p.columns       = columns.toJs
-    p.container     = container
-    p.divided       = divided.toJs
-    p.doubling      = doubling
-    p.inverted      = inverted
-    p.padded        = padded.toJs
-    p.relaxed       = relaxed.toJs
-    p.reversed      = reversed.toJs
-    p.stackable     = stackable
-    p.stretched     = stretched
-    p.textAlign     = textAlign.toJs
-    p.verticalAlign = verticalAlign.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    celled.toJs.foreach(v => p.celled                = v)
+    centered.foreach(v => p.centered                 = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    columns.toJs.foreach(v => p.columns              = v)
+    container.foreach(v => p.container               = v)
+    divided.toJs.foreach(v => p.divided              = v)
+    doubling.foreach(v => p.doubling                 = v)
+    inverted.foreach(v => p.inverted                 = v)
+    padded.toJs.foreach(v => p.padded                = v)
+    relaxed.toJs.foreach(v => p.relaxed              = v)
+    reversed.toJs.foreach(v => p.reversed            = v)
+    stackable.foreach(v => p.stackable               = v)
+    stretched.foreach(v => p.stretched               = v)
+    textAlign.toJs.foreach(v => p.textAlign          = v)
+    verticalAlign.toJs.foreach(v => p.verticalAlign  = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/grid/GridColumn.scala
+++ b/facade/src/main/scala/react/semanticui/collections/grid/GridColumn.scala
@@ -131,20 +131,20 @@ object GridColumn {
     width:         js.UndefOr[SemanticWidth]             = js.undefined
   ): GridColumnProps = {
     val p = as.toJsObject[GridColumnProps]
-    p.as            = as.toJs
-    p.className     = (className, clazz).toJs
-    p.color         = color.toJs
-    p.computer      = computer.toJs
-    p.floated       = floated.toJs
-    p.largeScreen   = largeScreen.toJs
-    p.mobile        = mobile.toJs
-    p.only          = only.toJs
-    p.stretched     = stretched
-    p.tablet        = tablet.toJs
-    p.textAlign     = textAlign.toJs
-    p.verticalAlign = verticalAlign.toJs
-    p.widescreen    = widescreen.toJs
-    p.width         = width.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    color.toJs.foreach(v => p.color                  = v)
+    computer.toJs.foreach(v => p.computer            = v)
+    floated.toJs.foreach(v => p.floated              = v)
+    largeScreen.toJs.foreach(v => p.largeScreen      = v)
+    mobile.toJs.foreach(v => p.mobile                = v)
+    only.toJs.foreach(v => p.only                    = v)
+    stretched.foreach(v => p.stretched               = v)
+    tablet.toJs.foreach(v => p.tablet                = v)
+    textAlign.toJs.foreach(v => p.textAlign          = v)
+    verticalAlign.toJs.foreach(v => p.verticalAlign  = v)
+    widescreen.toJs.foreach(v => p.widescreen        = v)
+    width.toJs.foreach(v => p.width                  = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/grid/GridRow.scala
+++ b/facade/src/main/scala/react/semanticui/collections/grid/GridRow.scala
@@ -112,20 +112,22 @@ object GridRow {
     verticalAlign: js.UndefOr[SemanticVerticalAlignment]   = js.undefined
   ): GridRowProps = {
     val p = as.toJsObject[GridRowProps]
-    p.as        = as.toJs
-    p.centered  = centered
-    p.className = (className, clazz).toJs
-    p.color     = color.toJs
-    p.columns = columns.map((_: Any) match {
-      case s: GridColumns => s.toJs
-      case s              => s.asInstanceOf[SemanticWidth].toJs
-    })
-    p.divided       = divided
-    p.only          = only.toJs
-    p.reversed      = reversed.toJs
-    p.stretched     = stretched
-    p.textAlign     = textAlign.toJs
-    p.verticalAlign = verticalAlign.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    centered.foreach(v => p.centered                 = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    color.toJs.foreach(v => p.color                  = v)
+    columns
+      .map((_: Any) match {
+        case s: GridColumns => s.toJs
+        case s              => s.asInstanceOf[SemanticWidth].toJs
+      })
+      .foreach(v => p.columns                       = v)
+    divided.foreach(v => p.divided                  = v)
+    only.toJs.foreach(v => p.only                   = v)
+    reversed.toJs.foreach(v => p.reversed           = v)
+    stretched.foreach(v => p.stretched              = v)
+    textAlign.toJs.foreach(v => p.textAlign         = v)
+    verticalAlign.toJs.foreach(v => p.verticalAlign = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/menu/Menu.scala
+++ b/facade/src/main/scala/react/semanticui/collections/menu/Menu.scala
@@ -200,28 +200,28 @@ object Menu {
     widths:             js.UndefOr[SemanticWidth] = js.undefined
   ): MenuProps = {
     val p = (new js.Object).asInstanceOf[MenuProps]
-    p.as                 = as.toJs
-    p.activeIndex        = activeIndex
-    p.attached           = attached.toJs
-    p.borderless         = borderless
-    p.className          = (className, clazz).toJs
-    p.compact            = compact
-    p.defaultActiveIndex = defaultActiveIndex
-    p.fixed              = fixed.toJs
-    p.floated            = floated.toJs
-    p.fluid              = fluid
-    p.icon               = icon.toJs
-    p.inverted           = inverted
-    p.onItemClick        = (onItemClickE, onItemClick).toJs
-    p.pagination         = pagination
-    p.pointing           = pointing
-    p.secondary          = secondary
-    p.size               = size.toJs
-    p.stackable          = stackable
-    p.tabular            = tabular.toJs
-    p.text               = text
-    p.vertical           = vertical
-    p.widths             = widths.toJs
+    as.toJs.foreach(v => p.as                                   = v)
+    activeIndex.foreach(v => p.activeIndex                      = v)
+    attached.toJs.foreach(v => p.attached                       = v)
+    borderless.foreach(v => p.borderless                        = v)
+    (className, clazz).toJs.foreach(v => p.className            = v)
+    compact.foreach(v => p.compact                              = v)
+    defaultActiveIndex.foreach(v => p.defaultActiveIndex        = v)
+    fixed.toJs.foreach(v => p.fixed                             = v)
+    floated.toJs.foreach(v => p.floated                         = v)
+    fluid.foreach(v => p.fluid                                  = v)
+    icon.toJs.foreach(v => p.icon                               = v)
+    inverted.foreach(v => p.inverted                            = v)
+    (onItemClickE, onItemClick).toJs.foreach(v => p.onItemClick = v)
+    pagination.foreach(v => p.pagination                        = v)
+    pointing.foreach(v => p.pointing                            = v)
+    secondary.foreach(v => p.secondary                          = v)
+    size.toJs.foreach(v => p.size                               = v)
+    stackable.foreach(v => p.stackable                          = v)
+    tabular.toJs.foreach(v => p.tabular                         = v)
+    text.foreach(v => p.text                                    = v)
+    vertical.foreach(v => p.vertical                            = v)
+    widths.toJs.foreach(v => p.widths                           = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/menu/MenuHeader.scala
+++ b/facade/src/main/scala/react/semanticui/collections/menu/MenuHeader.scala
@@ -61,9 +61,9 @@ object MenuHeader {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): MenuHeaderProps = {
     val p = as.toJsObject[MenuHeaderProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/menu/MenuItem.scala
+++ b/facade/src/main/scala/react/semanticui/collections/menu/MenuItem.scala
@@ -146,20 +146,20 @@ object MenuItem {
     position:  js.UndefOr[MenuItemPosition]     = js.undefined
   ): MenuItemProps = {
     val p = as.toJsObject[MenuItemProps]
-    p.as        = as.toJs
-    p.active    = active
-    p.className = (className, clazz).toJs
-    p.color     = color.toJs
-    p.content   = content.toJs
-    p.disabled  = disabled
-    p.fitted    = fitted.toJs
-    p.header    = header
-    p.icon      = icon.toJs
-    p.index     = index
-    p.link      = link
-    p.name      = name
-    p.onClick   = (onClickE, onClick).toJs
-    p.position  = position.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    active.foreach(v => p.active                     = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    color.toJs.foreach(v => p.color                  = v)
+    content.toJs.foreach(v => p.content              = v)
+    disabled.foreach(v => p.disabled                 = v)
+    fitted.toJs.foreach(v => p.fitted                = v)
+    header.foreach(v => p.header                     = v)
+    icon.toJs.foreach(v => p.icon                    = v)
+    index.foreach(v => p.index                       = v)
+    link.foreach(v => p.link                         = v)
+    name.foreach(v => p.name                         = v)
+    (onClickE, onClick).toJs.foreach(v => p.onClick  = v)
+    position.toJs.foreach(v => p.position            = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/menu/MenuMenu.scala
+++ b/facade/src/main/scala/react/semanticui/collections/menu/MenuMenu.scala
@@ -66,10 +66,10 @@ object MenuMenu {
     position:  js.UndefOr[MenuMenuPosition]     = js.undefined
   ): MenuMenuProps = {
     val p = as.toJsObject[MenuMenuProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
-    p.position  = position.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    position.toJs.foreach(v => p.position            = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/message/Message.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/Message.scala
@@ -46,6 +46,8 @@ final case class Message(
 
 object Message {
   type OnDismiss = (ReactEvent, MessageProps) => Callback
+  type RawList =
+    js.Array[suiraw.SemanticShorthandItemS[MessageItem.MessageItemProps]] | MessageList.MessageListProps
 
   @js.native
   @JSImport("semantic-ui-react", "Message")
@@ -101,9 +103,7 @@ object Message {
     var info: js.UndefOr[Boolean] = js.undefined
 
     /** Array shorthand items for the MessageList. Mutually exclusive with children. */
-    var list: js.UndefOr[
-      js.Array[suiraw.SemanticShorthandItemS[MessageItem.MessageItemProps]] | MessageList.MessageListProps
-    ] =
+    var list: js.UndefOr[RawList] =
       js.undefined
 
     /** A message may be formatted to display a negative message. Same as `error`. */
@@ -185,32 +185,34 @@ object Message {
     warning:    js.UndefOr[Boolean]                                    = js.undefined
   ): MessageProps = {
     val p = as.toJsObject[MessageProps]
-    p.as        = as.toJs
-    p.attached  = attached.toJs
-    p.className = (className, clazz).toJs
-    p.color     = color.toJs
-    p.compact   = compact
-    p.content   = content.toJs
-    p.error     = error
-    p.floating  = floating
-    p.header    = header.toJs
-    p.hidden    = hidden
-    p.icon      = icon.toJs
-    p.info      = info
-    p.list = list.map(v =>
-      (v: Any) match {
-        case s: Seq[_] =>
-          s.map(item => compToPropS(item.asInstanceOf[ShorthandS[MessageItem]])).toJSArray
-        // .asInstanceOf[raw.SemanticShorthandOrArray[T]]
-        case l: MessageList => l.props
-      }
-    )
-    p.negative  = negative
-    p.onDismiss = (onDismissE, onDismiss).toJs
-    p.positive  = positive
-    p.size      = size.toJs
-    p.visible   = visible
-    p.warning   = warning
+    as.toJs.foreach(v => p.as                        = v)
+    attached.toJs.foreach(v => p.attached            = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    color.toJs.foreach(v => p.color                  = v)
+    compact.foreach(v => p.compact                   = v)
+    content.toJs.foreach(v => p.content              = v)
+    error.foreach(v => p.error                       = v)
+    floating.foreach(v => p.floating                 = v)
+    header.toJs.foreach(v => p.header                = v)
+    hidden.foreach(v => p.hidden                     = v)
+    icon.toJs.foreach(v => p.icon                    = v)
+    info.foreach(v => p.info                         = v)
+    list
+      .map[RawList](v =>
+        (v: Any) match {
+          case s: Seq[_] =>
+            s.map(item => compToPropS(item.asInstanceOf[ShorthandS[MessageItem]])).toJSArray
+          // .asInstanceOf[raw.SemanticShorthandOrArray[T]]
+          case l: MessageList => l.props
+        }
+      )
+      .foreach(v => p.list                                = v)
+    negative.foreach(v => p.negative                      = v)
+    (onDismissE, onDismiss).toJs.foreach(v => p.onDismiss = v)
+    positive.foreach(v => p.positive                      = v)
+    size.toJs.foreach(v => p.size                         = v)
+    visible.foreach(v => p.visible                        = v)
+    warning.foreach(v => p.warning                        = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageContent.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageContent.scala
@@ -65,9 +65,9 @@ object MessageContent {
     content:   js.UndefOr[ShorthandS[MessageContent]] = js.undefined
   ): MessageContentProps = {
     val p = as.toJsObject[MessageContentProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageHeader.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageHeader.scala
@@ -66,9 +66,9 @@ object MessageHeader {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): MessageHeaderProps = {
     val p = as.toJsObject[MessageHeaderProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageItem.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageItem.scala
@@ -65,9 +65,9 @@ object MessageItem {
     content:   js.UndefOr[ShorthandS[MessageItem]] = js.undefined
   ): MessageItemProps = {
     val p = as.toJsObject[MessageItemProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/collections/message/MessageList.scala
+++ b/facade/src/main/scala/react/semanticui/collections/message/MessageList.scala
@@ -65,9 +65,9 @@ object MessageList {
     items:     js.UndefOr[Seq[ShorthandS[MessageItem]]] = js.undefined
   ): MessageListProps = {
     val p = as.toJsObject[MessageListProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.items     = items.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    items.toJs.foreach(v => p.items                  = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/button/Button.scala
+++ b/facade/src/main/scala/react/semanticui/elements/button/Button.scala
@@ -164,33 +164,33 @@ object Button {
     toggle:        js.UndefOr[Boolean]              = js.undefined
   ): ButtonProps = {
     val p = as.toJsObject[ButtonProps]
-    p.as            = as.toJs
-    p.active        = active
-    p.animated      = animated.toJs
-    p.attached      = attached.toJs
-    p.basic         = basic
-    p.circular      = circular
-    p.className     = (className, clazz).toJs
-    p.color         = color.toJs
-    p.compact       = compact
-    p.content       = content.toJs
-    p.disabled      = disabled
-    p.floated       = floated.toJs
-    p.fluid         = fluid
-    p.icon          = icon.toJs
-    p.inverted      = inverted
-    p.label         = label.toJs
-    p.labelPosition = labelPosition.toJs
-    p.loading       = loading
-    p.negative      = negative
-    p.onClick       = (onClickE, onClick).toJs
-    p.positive      = positive
-    p.primary       = primary
-    p.role          = role
-    p.secondary     = secondary
-    p.size          = size.toJs
-    p.tabIndex      = tabIndex
-    p.toggle        = toggle
+    as.toJs.foreach(v => p.as                        = v)
+    active.foreach(v => p.active                     = v)
+    animated.toJs.foreach(v => p.animated            = v)
+    attached.toJs.foreach(v => p.attached            = v)
+    basic.foreach(v => p.basic                       = v)
+    circular.foreach(v => p.circular                 = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    color.toJs.foreach(v => p.color                  = v)
+    compact.foreach(v => p.compact                   = v)
+    content.toJs.foreach(v => p.content              = v)
+    disabled.foreach(v => p.disabled                 = v)
+    floated.toJs.foreach(v => p.floated              = v)
+    fluid.foreach(v => p.fluid                       = v)
+    icon.toJs.foreach(v => p.icon                    = v)
+    inverted.foreach(v => p.inverted                 = v)
+    label.toJs.foreach(v => p.label                  = v)
+    labelPosition.toJs.foreach(v => p.labelPosition  = v)
+    loading.foreach(v => p.loading                   = v)
+    negative.foreach(v => p.negative                 = v)
+    (onClickE, onClick).toJs.foreach(v => p.onClick  = v)
+    positive.foreach(v => p.positive                 = v)
+    primary.foreach(v => p.primary                   = v)
+    role.foreach(v => p.role                         = v)
+    secondary.foreach(v => p.secondary               = v)
+    size.toJs.foreach(v => p.size                    = v)
+    tabIndex.foreach(v => p.tabIndex                 = v)
+    toggle.foreach(v => p.toggle                     = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/button/ButtonContent.scala
+++ b/facade/src/main/scala/react/semanticui/elements/button/ButtonContent.scala
@@ -72,11 +72,11 @@ object ButtonContent {
     visible:   js.UndefOr[Boolean]              = js.undefined
   ): ButtonContentProps = {
     val p = as.toJsObject[ButtonContentProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
-    p.hidden    = hidden
-    p.visible   = visible
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    hidden.foreach(v => p.hidden                     = v)
+    visible.foreach(v => p.visible                   = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/button/ButtonGroup.scala
+++ b/facade/src/main/scala/react/semanticui/elements/button/ButtonGroup.scala
@@ -174,26 +174,26 @@ object ButtonGroup {
     widths:    js.UndefOr[SemanticWidth]    = js.undefined
   ): ButtonGroupProps = {
     val p = as.toJsObject[ButtonGroupProps]
-    p.as        = as.toJs
-    p.attached  = attached
-    p.basic     = basic
-    p.buttons   = buttons.map(x => x.map(btn => btn.props).toJSArray)
-    p.className = (className, clazz).toJs
-    p.color     = color.toJs
-    p.compact   = compact
-    p.content   = content.map(_.map(_.rawNode).toJSArray)
-    p.floated   = floated.toJs
-    p.icon      = icon
-    p.inverted  = inverted
-    p.labeled   = labeled
-    p.negative  = negative
-    p.positive  = positive
-    p.primary   = primary
-    p.secondary = secondary
-    p.size      = size.toJs
-    p.toggle    = toggle
-    p.vertical  = vertical
-    p.widths    = widths.toJs
+    as.toJs.foreach(v => p.as                                                  = v)
+    attached.foreach(v => p.attached                                           = v)
+    basic.foreach(v => p.basic                                                 = v)
+    buttons.map(x => x.map(btn => btn.props).toJSArray).foreach(v => p.buttons = v)
+    (className, clazz).toJs.foreach(v => p.className                           = v)
+    color.toJs.foreach(v => p.color                                            = v)
+    compact.foreach(v => p.compact                                             = v)
+    content.map(_.map(_.rawNode).toJSArray).foreach(v => p.content             = v)
+    floated.toJs.foreach(v => p.floated                                        = v)
+    icon.foreach(v => p.icon                                                   = v)
+    inverted.foreach(v => p.inverted                                           = v)
+    labeled.foreach(v => p.labeled                                             = v)
+    negative.foreach(v => p.negative                                           = v)
+    positive.foreach(v => p.positive                                           = v)
+    primary.foreach(v => p.primary                                             = v)
+    secondary.foreach(v => p.secondary                                         = v)
+    size.toJs.foreach(v => p.size                                              = v)
+    toggle.foreach(v => p.toggle                                               = v)
+    vertical.foreach(v => p.vertical                                           = v)
+    widths.toJs.foreach(v => p.widths                                          = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/button/ButtonOr.scala
+++ b/facade/src/main/scala/react/semanticui/elements/button/ButtonOr.scala
@@ -58,9 +58,9 @@ object ButtonOr {
     text:      js.UndefOr[JsNumber | String] = js.undefined
   ): ButtonOrProps = {
     val p = as.toJsObject[ButtonOrProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.text      = text
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    text.foreach(v => p.text                         = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/container/Container.scala
+++ b/facade/src/main/scala/react/semanticui/elements/container/Container.scala
@@ -67,11 +67,11 @@ object Container {
     q: Container
   ): ContainerProps = {
     val p = q.as.toJsObject[ContainerProps]
-    p.className = (q.className, q.clazz).toJs
-    p.content   = q.content.toJs
-    p.fluid     = q.fluid
-    p.text      = q.text
-    p.textAlign = q.textAlign.toJs
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.fluid.foreach(v => p.fluid                         = v)
+    q.text.foreach(v => p.text                           = v)
+    q.textAlign.toJs.foreach(v => p.textAlign            = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/divider/Divider.scala
+++ b/facade/src/main/scala/react/semanticui/elements/divider/Divider.scala
@@ -83,16 +83,16 @@ object Divider {
     q: Divider
   ): DividerProps = {
     val p = q.as.toJsObject[DividerProps]
-    p.as         = q.as.toJs
-    p.className  = (q.className, q.clazz).toJs
-    p.clearing   = q.clearing
-    p.content    = q.content.toJs
-    p.fitted     = q.fitted
-    p.hidden     = q.hidden
-    p.horizontal = q.horizontal
-    p.inverted   = q.inverted
-    p.section    = q.section
-    p.vertical   = q.vertical
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.clearing.foreach(v => p.clearing                   = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.fitted.foreach(v => p.fitted                       = v)
+    q.hidden.foreach(v => p.hidden                       = v)
+    q.horizontal.foreach(v => p.horizontal               = v)
+    q.inverted.foreach(v => p.inverted                   = v)
+    q.section.foreach(v => p.section                     = v)
+    q.vertical.foreach(v => p.vertical                   = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/flag/Flag.scala
+++ b/facade/src/main/scala/react/semanticui/elements/flag/Flag.scala
@@ -49,9 +49,9 @@ object Flag {
     q: Flag
   ): FlagProps = {
     val p = q.as.toJsObject[FlagProps]
-    p.as        = q.as.toJs
-    p.className = (q.className, q.clazz).toJs
-    p.name      = q.name
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.name.foreach(v => p.name                           = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/header/Header.scala
+++ b/facade/src/main/scala/react/semanticui/elements/header/Header.scala
@@ -149,22 +149,22 @@ object Header {
     textAlign: js.UndefOr[SemanticTextAlignment] = js.undefined
   ): HeaderProps = {
     val p = as.toJsObject[HeaderProps]
-    p.as        = as.toJs
-    p.attached  = attached.toJs
-    p.block     = block
-    p.className = (className, clazz).toJs
-    p.color     = color.toJs
-    p.content   = content.toJs
-    p.disabled  = disabled
-    p.dividing  = dividing
-    p.floated   = floated.toJs
-    p.icon      = icon.toJs
-    p.image     = image
-    p.inverted  = inverted
-    p.size      = size.toJs
-    p.sub       = sub
-    p.subheader = subheader.map(_.props)
-    p.textAlign = textAlign.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    attached.toJs.foreach(v => p.attached            = v)
+    block.foreach(v => p.block                       = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    color.toJs.foreach(v => p.color                  = v)
+    content.toJs.foreach(v => p.content              = v)
+    disabled.foreach(v => p.disabled                 = v)
+    dividing.foreach(v => p.dividing                 = v)
+    floated.toJs.foreach(v => p.floated              = v)
+    icon.toJs.foreach(v => p.icon                    = v)
+    image.foreach(v => p.image                       = v)
+    inverted.foreach(v => p.inverted                 = v)
+    size.toJs.foreach(v => p.size                    = v)
+    sub.foreach(v => p.sub                           = v)
+    subheader.map(_.props).foreach(v => p.subheader  = v)
+    textAlign.toJs.foreach(v => p.textAlign          = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/header/HeaderContent.scala
+++ b/facade/src/main/scala/react/semanticui/elements/header/HeaderContent.scala
@@ -63,9 +63,9 @@ object HeaderContent {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): HeaderContentProps = {
     val p = as.toJsObject[HeaderContentProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/header/HeaderSubheader.scala
+++ b/facade/src/main/scala/react/semanticui/elements/header/HeaderSubheader.scala
@@ -55,9 +55,9 @@ object HeaderSubheader {
     q: HeaderSubheader
   ): HeaderSubheaderProps = {
     val p = q.as.toJsObject[HeaderSubheaderProps]
-    p.as        = q.as.toJs
-    p.className = (q.className, q.clazz).toJs
-    p.content   = q.content.toJs
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/icon/Icon.scala
+++ b/facade/src/main/scala/react/semanticui/elements/icon/Icon.scala
@@ -69,21 +69,21 @@ object Icon {
     q: Icon
   ): IconProps = {
     val p = q.as.toJsObject[IconProps]
-    p.as           = q.as.toJs
-    p.bordered     = q.bordered
-    p.circular     = q.circular
-    p.className    = (q.className, q.clazz).toJs
-    p.color        = q.color.toJs
-    p.corner       = q.corner.toJs
-    p.disabled     = q.disabled
-    p.fitted       = q.fitted
-    p.flipped      = q.flipped.toJs
-    p.inverted     = q.inverted
-    p.link         = q.link
-    p.loading      = q.loading
-    p.name         = q.name
-    p.rotated      = q.rotated.toJs
-    p.size         = q.size.toJs
+    q.as.toJs.foreach(v => p.as                          = v)
+    q.bordered.foreach(v => p.bordered                   = v)
+    q.circular.foreach(v => p.circular                   = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.color.toJs.foreach(v => p.color                    = v)
+    q.corner.toJs.foreach(v => p.corner                  = v)
+    q.disabled.foreach(v => p.disabled                   = v)
+    q.fitted.foreach(v => p.fitted                       = v)
+    q.flipped.toJs.foreach(v => p.flipped                = v)
+    q.inverted.foreach(v => p.inverted                   = v)
+    q.link.foreach(v => p.link                           = v)
+    q.loading.foreach(v => p.loading                     = v)
+    q.name.foreach(v => p.name                           = v)
+    q.rotated.toJs.foreach(v => p.rotated                = v)
+    q.size.toJs.foreach(v => p.size                      = v)
     p.`aria-label` = q.ariaLabel
     p
   }

--- a/facade/src/main/scala/react/semanticui/elements/icon/IconGroup.scala
+++ b/facade/src/main/scala/react/semanticui/elements/icon/IconGroup.scala
@@ -38,10 +38,10 @@ object IconGroup {
     q: IconGroup
   ): IconGroupProps = {
     val p = q.as.toJsObject[IconGroupProps]
-    p.as        = q.as.toJs
-    p.className = (q.className, q.clazz).toJs
-    p.content   = q.content.toJs
-    p.size      = q.size.toJs
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.size.toJs.foreach(v => p.size                      = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/image/Image.scala
+++ b/facade/src/main/scala/react/semanticui/elements/image/Image.scala
@@ -135,28 +135,28 @@ object Image {
     q: Image
   ): ImageProps = {
     val p = q.as.toJsObject[ImageProps]
-    p.as            = q.as.toJs
-    p.avatar        = q.avatar
-    p.bordered      = q.bordered
-    p.centered      = q.centered
-    p.circular      = q.circular
-    p.className     = (q.className, q.clazz).toJs
-    p.content       = q.content.map(_.rawNode)
-    p.disabled      = q.disabled
-    p.dimmer        = q.dimmer.map(_.props)
-    p.floated       = q.floated.toJs
-    p.fluid         = q.fluid
-    p.hidden        = q.hidden
-    p.href          = q.href
-    p.inline        = q.inline
-    p.label         = q.label.toJs
-    p.rounded       = q.rounded
-    p.size          = q.size.toJs
-    p.spaced        = q.spaced.toJs
-    p.src           = q.src
-    p.ui            = q.ui
-    p.verticalAlign = q.verticalAlign.toJs
-    p.wrapped       = q.wrapped
+    q.as.toJs.foreach(v => p.as                          = v)
+    q.avatar.foreach(v => p.avatar                       = v)
+    q.bordered.foreach(v => p.bordered                   = v)
+    q.centered.foreach(v => p.centered                   = v)
+    q.circular.foreach(v => p.circular                   = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.map(_.rawNode).foreach(v => p.content      = v)
+    q.disabled.foreach(v => p.disabled                   = v)
+    q.dimmer.map(_.props).foreach(v => p.dimmer          = v)
+    q.floated.toJs.foreach(v => p.floated                = v)
+    q.fluid.foreach(v => p.fluid                         = v)
+    q.hidden.foreach(v => p.hidden                       = v)
+    q.href.foreach(v => p.href                           = v)
+    q.inline.foreach(v => p.inline                       = v)
+    q.label.toJs.foreach(v => p.label                    = v)
+    q.rounded.foreach(v => p.rounded                     = v)
+    q.size.toJs.foreach(v => p.size                      = v)
+    q.spaced.toJs.foreach(v => p.spaced                  = v)
+    q.src.foreach(v => p.src                             = v)
+    q.ui.foreach(v => p.ui                               = v)
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign    = v)
+    q.wrapped.foreach(v => p.wrapped                     = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/input/Input.scala
+++ b/facade/src/main/scala/react/semanticui/elements/input/Input.scala
@@ -134,26 +134,26 @@ object Input {
     q: Input
   ): InputProps = {
     val p = q.as.toJsObject[InputProps]
-    p.as             = q.as.toJs
-    p.action         = q.action.toJs
-    p.actionPosition = q.actionPosition.toJs
-    p.className      = (q.className, q.clazz).toJs
-    p.disabled       = q.disabled
-    p.error          = q.error
-    p.fluid          = q.fluid
-    p.focus          = q.focus
-    p.icon           = q.icon.toJs
-    p.iconPosition   = q.iconPosition.toJs
-    p.input          = q.input.toJs
-    p.inverted       = q.inverted
-    p.label          = q.label.toJs
-    p.labelPosition  = q.labelPosition.toJs
-    p.loading        = q.loading
-    p.onChange       = (q.onChangeE, q.onChange).toJs
-    p.size           = q.size.toJs
-    p.tabIndex       = q.tabIndex
-    p.transparent    = q.transparent
-    p.`type`         = q.tpe
+    q.as.toJs.foreach(v => p.as                            = v)
+    q.action.toJs.foreach(v => p.action                    = v)
+    q.actionPosition.toJs.foreach(v => p.actionPosition    = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className   = v)
+    q.disabled.foreach(v => p.disabled                     = v)
+    q.error.foreach(v => p.error                           = v)
+    q.fluid.foreach(v => p.fluid                           = v)
+    q.focus.foreach(v => p.focus                           = v)
+    q.icon.toJs.foreach(v => p.icon                        = v)
+    q.iconPosition.toJs.foreach(v => p.iconPosition        = v)
+    q.input.toJs.foreach(v => p.input                      = v)
+    q.inverted.foreach(v => p.inverted                     = v)
+    q.label.toJs.foreach(v => p.label                      = v)
+    q.labelPosition.toJs.foreach(v => p.labelPosition      = v)
+    q.loading.foreach(v => p.loading                       = v)
+    (q.onChangeE, q.onChange).toJs.foreach(v => p.onChange = v)
+    q.size.toJs.foreach(v => p.size                        = v)
+    q.tabIndex.foreach(v => p.tabIndex                     = v)
+    q.transparent.foreach(v => p.transparent               = v)
+    p.`type` = q.tpe
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/label/Label.scala
+++ b/facade/src/main/scala/react/semanticui/elements/label/Label.scala
@@ -101,30 +101,30 @@ object Label {
     q: Label
   ): LabelProps = {
     val p = q.as.toJsObject[LabelProps]
-    p.as         = q.as.toJs
-    p.active     = q.active
-    p.attached   = q.attached.toJs
-    p.basic      = q.basic
-    p.children   = q.child
-    p.circular   = q.circular
-    p.className  = (q.className, q.clazz).toJs
-    p.color      = q.color.toJs
-    p.content    = q.content.toJs
-    p.corner     = q.corner.toJs
-    p.detail     = q.detail.map(_.props)
-    p.empty      = q.empty.map(_.asInstanceOf[js.Any])
-    p.floating   = q.floating
-    p.horizontal = q.horizontal
-    p.icon       = q.icon.toJs
-    p.image      = q.image.map(_.asInstanceOf[js.Any])
-    p.onClick    = (q.onClickE, q.onClick).toJs
-    p.onRemove   = q.onRemove.toJs
-    p.pointing   = q.pointing.toJs
-    p.prompt     = q.prompt
-    p.removeIcon = q.removeIcon.toJs
-    p.ribbon     = q.ribbon.toJs
-    p.size       = q.size.toJs
-    p.tag        = q.tag
+    q.as.toJs.foreach(v => p.as                              = v)
+    q.active.foreach(v => p.active                           = v)
+    q.attached.toJs.foreach(v => p.attached                  = v)
+    q.basic.foreach(v => p.basic                             = v)
+    q.child.foreach(v => p.children                          = v)
+    q.circular.foreach(v => p.circular                       = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className     = v)
+    q.color.toJs.foreach(v => p.color                        = v)
+    q.content.toJs.foreach(v => p.content                    = v)
+    q.corner.toJs.foreach(v => p.corner                      = v)
+    q.detail.map(_.props).foreach(v => p.detail              = v)
+    q.empty.map(_.asInstanceOf[js.Any]).foreach(v => p.empty = v)
+    q.floating.foreach(v => p.floating                       = v)
+    q.horizontal.foreach(v => p.horizontal                   = v)
+    q.icon.toJs.foreach(v => p.icon                          = v)
+    q.image.map(_.asInstanceOf[js.Any]).foreach(v => p.image = v)
+    (q.onClickE, q.onClick).toJs.foreach(v => p.onClick      = v)
+    q.onRemove.toJs.foreach(v => p.onRemove                  = v)
+    q.pointing.toJs.foreach(v => p.pointing                  = v)
+    q.prompt.foreach(v => p.prompt                           = v)
+    q.removeIcon.toJs.foreach(v => p.removeIcon              = v)
+    q.ribbon.toJs.foreach(v => p.ribbon                      = v)
+    q.size.toJs.foreach(v => p.size                          = v)
+    q.tag.foreach(v => p.tag                                 = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/label/LabelDetail.scala
+++ b/facade/src/main/scala/react/semanticui/elements/label/LabelDetail.scala
@@ -45,9 +45,9 @@ object LabelDetail {
     q: LabelDetail
   ): LabelDetailProps = {
     val p = q.as.toJsObject[LabelDetailProps]
-    p.as        = q.as.toJs
-    p.className = (q.className, q.clazz).toJs
-    p.content   = q.content.toJs
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/list/List.scala
+++ b/facade/src/main/scala/react/semanticui/elements/list/List.scala
@@ -127,24 +127,24 @@ object List {
     q: List
   ): ListProps = {
     val p = q.as.toJsObject[ListProps]
-    p.as            = q.as.toJs
-    p.animated      = q.animated
-    p.bulleted      = q.bulleted
-    p.celled        = q.celled
-    p.className     = (q.className, q.clazz).toJs
-    p.content       = q.content.map(_.map(_.rawNode).toJSArray)
-    p.divided       = q.divided
-    p.floated       = q.floated.toJs
-    p.horizontal    = q.horizontal
-    p.inverted      = q.inverted
-    p.items         = q.items.toJs
-    p.onItemClick   = (q.onItemClickE, q.onItemClick).toJs
-    p.link          = q.link
-    p.ordered       = q.ordered
-    p.relaxed       = q.relaxed
-    p.selection     = q.selection
-    p.size          = q.size.toJs
-    p.verticalAlign = q.verticalAlign.toJs
+    q.as.toJs.foreach(v => p.as                                      = v)
+    q.animated.foreach(v => p.animated                               = v)
+    q.bulleted.foreach(v => p.bulleted                               = v)
+    q.celled.foreach(v => p.celled                                   = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className             = v)
+    q.content.map(_.map(_.rawNode).toJSArray).foreach(v => p.content = v)
+    q.divided.foreach(v => p.divided                                 = v)
+    q.floated.toJs.foreach(v => p.floated                            = v)
+    q.horizontal.foreach(v => p.horizontal                           = v)
+    q.inverted.foreach(v => p.inverted                               = v)
+    q.items.toJs.foreach(v => p.items                                = v)
+    (q.onItemClickE, q.onItemClick).toJs.foreach(v => p.onItemClick  = v)
+    q.link.foreach(v => p.link                                       = v)
+    q.ordered.foreach(v => p.ordered                                 = v)
+    q.relaxed.foreach(v => p.relaxed                                 = v)
+    q.selection.foreach(v => p.selection                             = v)
+    q.size.toJs.foreach(v => p.size                                  = v)
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign                = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/list/ListContent.scala
+++ b/facade/src/main/scala/react/semanticui/elements/list/ListContent.scala
@@ -93,13 +93,13 @@ object ListContent {
     verticalAlign: js.UndefOr[SemanticVerticalAlignment]   = js.undefined
   ): ListContentProps = {
     val p = as.toJsObject[ListContentProps]
-    p.as            = as.toJs
-    p.className     = (className, clazz).toJs
-    p.content       = content.map(_.map(_.rawNode).toJSArray)
-    p.description   = description.toJs
-    p.floated       = floated.toJs
-    p.header        = header.map(_.props)
-    p.verticalAlign = verticalAlign.toJs
+    as.toJs.foreach(v => p.as                                      = v)
+    (className, clazz).toJs.foreach(v => p.className               = v)
+    content.map(_.map(_.rawNode).toJSArray).foreach(v => p.content = v)
+    description.toJs.foreach(v => p.description                    = v)
+    floated.toJs.foreach(v => p.floated                            = v)
+    header.map(_.props).foreach(v => p.header                      = v)
+    verticalAlign.toJs.foreach(v => p.verticalAlign                = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/list/ListDescription.scala
+++ b/facade/src/main/scala/react/semanticui/elements/list/ListDescription.scala
@@ -62,9 +62,9 @@ object ListDescription {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): ListDescriptionProps = {
     val p = as.toJsObject[ListDescriptionProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/list/ListHeader.scala
+++ b/facade/src/main/scala/react/semanticui/elements/list/ListHeader.scala
@@ -63,9 +63,9 @@ object ListHeader {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): ListHeaderProps = {
     val p = as.toJsObject[ListHeaderProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/list/ListIcon.scala
+++ b/facade/src/main/scala/react/semanticui/elements/list/ListIcon.scala
@@ -52,23 +52,23 @@ object ListIcon {
     q: ListIcon
   ): ListIconProps = {
     val p = q.as.toJsObject[ListIconProps]
-    p.as            = q.as.toJs
-    p.bordered      = q.bordered
-    p.circular      = q.circular
-    p.className     = (q.className, q.clazz).toJs
-    p.color         = q.color.toJs
-    p.corner        = q.corner.toJs
-    p.disabled      = q.disabled
-    p.fitted        = q.fitted
-    p.flipped       = q.flipped.toJs
-    p.inverted      = q.inverted
-    p.link          = q.link
-    p.loading       = q.loading
-    p.name          = q.name
-    p.rotated       = q.rotated.toJs
-    p.size          = q.size.toJs
-    p.`aria-label`  = q.ariaLabel
-    p.verticalAlign = q.verticalAlign.toJs
+    q.as.toJs.foreach(v => p.as                          = v)
+    q.bordered.foreach(v => p.bordered                   = v)
+    q.circular.foreach(v => p.circular                   = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.color.toJs.foreach(v => p.color                    = v)
+    q.corner.toJs.foreach(v => p.corner                  = v)
+    q.disabled.foreach(v => p.disabled                   = v)
+    q.fitted.foreach(v => p.fitted                       = v)
+    q.flipped.toJs.foreach(v => p.flipped                = v)
+    q.inverted.foreach(v => p.inverted                   = v)
+    q.link.foreach(v => p.link                           = v)
+    q.loading.foreach(v => p.loading                     = v)
+    q.name.foreach(v => p.name                           = v)
+    q.rotated.toJs.foreach(v => p.rotated                = v)
+    q.size.toJs.foreach(v => p.size                      = v)
+    p.`aria-label` = q.ariaLabel
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/list/ListItem.scala
+++ b/facade/src/main/scala/react/semanticui/elements/list/ListItem.scala
@@ -124,17 +124,17 @@ object ListItem {
     value:       js.UndefOr[String]                      = js.undefined
   ): ListItemProps = {
     val p = as.toJsObject[ListItemProps]
-    p.as          = as.toJs
-    p.active      = active
-    p.className   = (className, clazz).toJs
-    p.content     = content.toJs
-    p.description = description.toJs
-    p.disabled    = disabled
-    p.header      = header.toJs
-    p.icon        = icon.toJs
-    p.image       = image.toJs
-    p.onClick     = (onClickE, onClick).toJs
-    p.value       = value
+    as.toJs.foreach(v => p.as                        = v)
+    active.foreach(v => p.active                     = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    description.toJs.foreach(v => p.description      = v)
+    disabled.foreach(v => p.disabled                 = v)
+    header.toJs.foreach(v => p.header                = v)
+    icon.toJs.foreach(v => p.icon                    = v)
+    image.toJs.foreach(v => p.image                  = v)
+    (onClickE, onClick).toJs.foreach(v => p.onClick  = v)
+    value.foreach(v => p.value                       = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/list/ListList.scala
+++ b/facade/src/main/scala/react/semanticui/elements/list/ListList.scala
@@ -63,9 +63,9 @@ object ListList {
     content:   js.UndefOr[VdomNode] = js.undefined
   ): ListListProps = {
     val p = as.toJsObject[ListListProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/loader/Loader.scala
+++ b/facade/src/main/scala/react/semanticui/elements/loader/Loader.scala
@@ -80,15 +80,15 @@ object Loader {
     q: Loader
   ): LoaderProps = {
     val p = q.as.toJsObject[LoaderProps]
-    p.as            = q.as.toJs
-    p.active        = q.active
-    p.className     = (q.className, q.clazz).toJs
-    p.content       = q.content.toJs
-    p.disabled      = q.disabled
-    p.indeterminate = q.indeterminate
-    p.inline        = q.inline.toJs
-    p.inverted      = q.inverted
-    p.size          = q.size.toJs
+    q.as.toJs.foreach(v => p.as                          = v)
+    q.active.foreach(v => p.active                       = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.disabled.foreach(v => p.disabled                   = v)
+    q.indeterminate.foreach(v => p.indeterminate         = v)
+    q.inline.toJs.foreach(v => p.inline                  = v)
+    q.inverted.foreach(v => p.inverted                   = v)
+    q.size.toJs.foreach(v => p.size                      = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/placeholder/Placeholder.scala
+++ b/facade/src/main/scala/react/semanticui/elements/placeholder/Placeholder.scala
@@ -63,11 +63,11 @@ object Placeholder {
     q: Placeholder
   ): PlaceholderProps = {
     val p = q.as.toJsObject[PlaceholderProps]
-    p.as        = q.as.toJs
-    p.className = (q.className, q.clazz).toJs
-    p.content   = q.content.toJs
-    p.fluid     = q.fluid
-    p.inverted  = q.inverted
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.fluid.foreach(v => p.fluid                         = v)
+    q.inverted.foreach(v => p.inverted                   = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/placeholder/PlaceholderHeader.scala
+++ b/facade/src/main/scala/react/semanticui/elements/placeholder/PlaceholderHeader.scala
@@ -62,10 +62,10 @@ object PlaceholderHeader {
     q: PlaceholderHeader
   ): PlaceholderHeaderProps = {
     val p = q.as.toJsObject[PlaceholderHeaderProps]
-    p.as        = q.as.toJs
-    p.className = (q.className, q.clazz).toJs
-    p.content   = q.content.toJs
-    p.image     = q.image
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.image.foreach(v => p.image                         = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/placeholder/PlaceholderImage.scala
+++ b/facade/src/main/scala/react/semanticui/elements/placeholder/PlaceholderImage.scala
@@ -66,11 +66,11 @@ object PlaceholderImage {
     q: PlaceholderImage
   ): PlaceholderImageProps = {
     val p = q.as.toJsObject[PlaceholderImageProps]
-    p.as          = q.as.toJs
-    p.className   = (q.className, q.clazz).toJs
-    p.content     = q.content.toJs
-    p.square      = q.square
-    p.rectangular = q.rectangular
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.square.foreach(v => p.square                       = v)
+    q.rectangular.foreach(v => p.rectangular             = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/placeholder/PlaceholderLine.scala
+++ b/facade/src/main/scala/react/semanticui/elements/placeholder/PlaceholderLine.scala
@@ -56,9 +56,9 @@ object PlaceholderLine {
     q: PlaceholderLine
   ): PlaceholderLineProps = {
     val p = q.as.toJsObject[PlaceholderLineProps]
-    p.as        = q.as.toJs
-    p.className = (q.className, q.clazz).toJs
-    p.length    = q.length.toJs
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.length.toJs.foreach(v => p.length                  = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/placeholder/PlaceholderParagraph.scala
+++ b/facade/src/main/scala/react/semanticui/elements/placeholder/PlaceholderParagraph.scala
@@ -58,9 +58,9 @@ object PlaceholderParagraph {
     q: PlaceholderParagraph
   ): PlaceholderParagraphProps = {
     val p = q.as.toJsObject[PlaceholderParagraphProps]
-    p.as        = q.as.toJs
-    p.className = (q.className, q.clazz).toJs
-    p.content   = q.content.toJs
+    q.as.toJs.foreach(v => p.as                          = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/rail/Rail.scala
+++ b/facade/src/main/scala/react/semanticui/elements/rail/Rail.scala
@@ -105,14 +105,14 @@ object Rail {
     size:      js.UndefOr[SemanticSize]         = js.undefined
   ): RailProps = {
     val p = as.toJsObject[RailProps]
-    p.attached  = attached
-    p.className = (className, clazz).toJs
-    p.close     = close.toJs
-    p.content   = content.toJs
-    p.dividing  = dividing
-    p.internal  = internal
-    p.position  = position.toJs
-    p.size      = size.toJs
+    attached.foreach(v => p.attached                 = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    close.toJs.foreach(v => p.close                  = v)
+    content.toJs.foreach(v => p.content              = v)
+    dividing.foreach(v => p.dividing                 = v)
+    internal.foreach(v => p.internal                 = v)
+    position.toJs.foreach(v => p.position            = v)
+    size.toJs.foreach(v => p.size                    = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/elements/segment/Segment.scala
+++ b/facade/src/main/scala/react/semanticui/elements/segment/Segment.scala
@@ -92,29 +92,29 @@ object Segment {
     q: Segment
   ): SegmentProps = {
     val p = q.as.toJsObject[SegmentProps]
-    p.as          = q.as.toJs
-    p.attached    = q.attached.toJs
-    p.basic       = q.basic
-    p.circular    = q.circular
-    p.className   = (q.className, q.clazz).toJs
-    p.clearing    = q.clearing
-    p.color       = q.color.toJs
-    p.compact     = q.compact
-    p.content     = q.content.toJs
-    p.disabled    = q.disabled
-    p.floated     = q.floated.toJs
-    p.inverted    = q.inverted
-    p.loading     = q.loading
-    p.padded      = q.padded
-    p.placeholder = q.placeholder
-    p.piled       = q.piled
-    p.raised      = q.raised
-    p.secondary   = q.secondary
-    p.size        = q.size.toJs
-    p.stacked     = q.stacked
-    p.tertiary    = q.tertiary
-    p.textAlign   = q.textAlign.toJs
-    p.vertical    = q.vertical
+    q.as.toJs.foreach(v => p.as                          = v)
+    q.attached.toJs.foreach(v => p.attached              = v)
+    q.basic.foreach(v => p.basic                         = v)
+    q.circular.foreach(v => p.circular                   = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.clearing.foreach(v => p.clearing                   = v)
+    q.color.toJs.foreach(v => p.color                    = v)
+    q.compact.foreach(v => p.compact                     = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.disabled.foreach(v => p.disabled                   = v)
+    q.floated.toJs.foreach(v => p.floated                = v)
+    q.inverted.foreach(v => p.inverted                   = v)
+    q.loading.foreach(v => p.loading                     = v)
+    q.padded.foreach(v => p.padded                       = v)
+    q.placeholder.foreach(v => p.placeholder             = v)
+    q.piled.foreach(v => p.piled                         = v)
+    q.raised.foreach(v => p.raised                       = v)
+    q.secondary.foreach(v => p.secondary                 = v)
+    q.size.toJs.foreach(v => p.size                      = v)
+    q.stacked.foreach(v => p.stacked                     = v)
+    q.tertiary.foreach(v => p.tertiary                   = v)
+    q.textAlign.toJs.foreach(v => p.textAlign            = v)
+    q.vertical.foreach(v => p.vertical                   = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/checkbox/Checkbox.scala
+++ b/facade/src/main/scala/react/semanticui/modules/checkbox/Checkbox.scala
@@ -213,28 +213,28 @@ object Checkbox {
     value:                js.UndefOr[String | JsNumber] = js.undefined
   ): CheckboxProps = {
     val p = as.toJsObject[CheckboxProps]
-    p.as                   = as.toJs
-    p.checked              = checked
-    p.className            = (className, clazz).toJs
-    p.defaultChecked       = defaultChecked
-    p.defaultIndeterminate = defaultIndeterminate
-    p.disabled             = disabled
-    p.fitted               = fitted
-    p.id                   = id
-    p.indeterminate        = indeterminate
-    p.label                = label.toJs
-    p.name                 = name
-    p.onChange             = (onChangeE, onChange).toJs
-    p.onClick              = (onClickE, onClick).toJs
-    p.onMouseDown          = (onMouseDownE, onMouseDown).toJs
-    p.onMouseUp            = (onMouseUpE, onMouseUp).toJs
-    p.radio                = radio
-    p.readOnly             = readOnly
-    p.slider               = slider
-    p.tabIndex             = tabIndex
-    p.toggle               = toggle
-    p.`type`               = `type`.toJs
-    p.value                = value
+    as.toJs.foreach(v => p.as                                   = v)
+    checked.foreach(v => p.checked                              = v)
+    (className, clazz).toJs.foreach(v => p.className            = v)
+    defaultChecked.foreach(v => p.defaultChecked                = v)
+    defaultIndeterminate.foreach(v => p.defaultIndeterminate    = v)
+    disabled.foreach(v => p.disabled                            = v)
+    fitted.foreach(v => p.fitted                                = v)
+    id.foreach(v => p.id                                        = v)
+    indeterminate.foreach(v => p.indeterminate                  = v)
+    label.toJs.foreach(v => p.label                             = v)
+    name.foreach(v => p.name                                    = v)
+    (onChangeE, onChange).toJs.foreach(v => p.onChange          = v)
+    (onClickE, onClick).toJs.foreach(v => p.onClick             = v)
+    (onMouseDownE, onMouseDown).toJs.foreach(v => p.onMouseDown = v)
+    (onMouseUpE, onMouseUp).toJs.foreach(v => p.onMouseUp       = v)
+    radio.foreach(v => p.radio                                  = v)
+    readOnly.foreach(v => p.readOnly                            = v)
+    slider.foreach(v => p.slider                                = v)
+    tabIndex.foreach(v => p.tabIndex                            = v)
+    toggle.foreach(v => p.toggle                                = v)
+    p.`type` = `type`.toJs
+    value.foreach(v => p.value = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dimmer/Dimmer.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dimmer/Dimmer.scala
@@ -44,8 +44,8 @@ object Dimmer {
     page:   js.UndefOr[Boolean] = js.undefined
   ): DimmerProps = {
     val p = (new js.Object).asInstanceOf[DimmerProps]
-    p.active = active
-    p.page   = page
+    active.foreach(v => p.active = v)
+    page.foreach(v => p.page     = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dimmer/DimmerDimmable.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dimmer/DimmerDimmable.scala
@@ -71,11 +71,11 @@ object DimmerDimmable {
     dimmed:    js.UndefOr[Boolean]  = js.undefined
   ): DimmerDimmableProps = {
     val p = as.toJsObject[DimmerDimmableProps]
-    p.as        = as.toJs
-    p.blurring  = blurring
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
-    p.dimmed    = dimmed
+    as.toJs.foreach(v => p.as                        = v)
+    blurring.foreach(v => p.blurring                 = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    dimmed.foreach(v => p.dimmed                     = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dimmer/DimmerInner.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dimmer/DimmerInner.scala
@@ -134,16 +134,16 @@ object DimmerInner {
     verticalAlign:   js.UndefOr[DimmerVerticalAlign] = js.undefined
   ): DimmerInnerProps = {
     val p = as.toJsObject[DimmerInnerProps]
-    p.as             = as.toJs
-    p.active         = active
-    p.className      = (className, clazz).toJs
-    p.disabled       = disabled
-    p.onClick        = (onClickE, onClick).toJs
-    p.onClickOutside = (onClickOutsideE, onClickOutside).toJs
-    p.inverted       = inverted
-    p.page           = page
-    p.simple         = simple
-    p.verticalAlign  = verticalAlign.toJs
+    as.toJs.foreach(v => p.as                                            = v)
+    active.foreach(v => p.active                                         = v)
+    (className, clazz).toJs.foreach(v => p.className                     = v)
+    disabled.foreach(v => p.disabled                                     = v)
+    (onClickE, onClick).toJs.foreach(v => p.onClick                      = v)
+    (onClickOutsideE, onClickOutside).toJs.foreach(v => p.onClickOutside = v)
+    inverted.foreach(v => p.inverted                                     = v)
+    page.foreach(v => p.page                                             = v)
+    simple.foreach(v => p.simple                                         = v)
+    verticalAlign.toJs.foreach(v => p.verticalAlign                      = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dropdown/Dropdown.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dropdown/Dropdown.scala
@@ -59,6 +59,7 @@ final case class Dropdown(
   onBlur:                 js.UndefOr[Callback]                          = js.undefined,
   onClickE:               js.UndefOr[Dropdown.OnClick]                  = js.undefined,
   onClick:                js.UndefOr[Callback]                          = js.undefined,
+  onChangeE:              js.UndefOr[Dropdown.OnChangeE]                = js.undefined,
   onChange:               js.UndefOr[Dropdown.OnChange]                 = js.undefined,
   onCloseE:               js.UndefOr[Dropdown.OnClose]                  = js.undefined,
   onClose:                js.UndefOr[Callback]                          = js.undefined,
@@ -113,7 +114,7 @@ object Dropdown {
     List[DropdownItem.DropdownItemProps],
     String
   ) => CallbackTo[List[DropdownItem.DropdownItemProps]]
-  private type RawRenderLabel =
+  type RawRenderLabel =
     js.Function3[DropdownItem.DropdownItemProps, Int, Label.LabelProps, Label.LabelProps]
   type RenderLabel =
     (DropdownItem.DropdownItemProps, Int, Label.LabelProps) => CallbackTo[Label.LabelProps]
@@ -121,16 +122,17 @@ object Dropdown {
   type OnAddItem               = (ReactKeyboardEvent, DropdownProps) => Callback
   private type RawOnBlur       = RawOnAddItem
   type OnBlur                  = OnAddItem
-  private type RawOnChange     = js.Function2[ReactEvent, DropdownProps, Unit]
-  type OnChange                = (ReactEvent, DropdownProps) => Callback
+  type RawOnChange             = js.Function2[ReactEvent, DropdownProps, Unit]
+  type OnChangeE               = (ReactEvent, DropdownProps) => Callback
+  type OnChange                = DropdownProps => Callback
   private type RawOnClick      = js.Function2[ReactMouseEvent, DropdownProps, Unit]
   type OnClick                 = (ReactMouseEvent, DropdownProps) => Callback
   private type RawOnClose      = RawOnChange
-  type OnClose                 = OnChange
+  type OnClose                 = OnChangeE
   private type RawOnFocus      = RawOnChange
-  type OnFocus                 = OnChange
+  type OnFocus                 = OnChangeE
   private type RawOnOpen       = RawOnChange
-  type OnOpen                  = OnChange
+  type OnOpen                  = OnChangeE
   private type RawOnLabelClick = js.Function2[ReactMouseEvent, Label.LabelProps, Unit]
   type OnLabelClick            = (ReactMouseEvent, Label.LabelProps) => Callback
   private type RawOnMouseDown  = RawOnLabelClick
@@ -465,6 +467,7 @@ object Dropdown {
       q.onBlur,
       q.onClickE,
       q.onClick,
+      q.onChangeE,
       q.onChange,
       q.onCloseE,
       q.onClose,
@@ -541,6 +544,7 @@ object Dropdown {
     onBlur:               js.UndefOr[Callback]                 = js.undefined,
     onClickE:             js.UndefOr[OnClick]                  = js.undefined,
     onClick:              js.UndefOr[Callback]                 = js.undefined,
+    onChangeE:            js.UndefOr[OnChangeE]                = js.undefined,
     onChange:             js.UndefOr[OnChange]                 = js.undefined,
     onCloseE:             js.UndefOr[OnClose]                  = js.undefined,
     onClose:              js.UndefOr[Callback]                 = js.undefined,
@@ -577,96 +581,108 @@ object Dropdown {
     wrapSelection:        js.UndefOr[Boolean]                  = js.undefined
   ): DropdownProps = {
     val p = as.toJsObject[DropdownProps]
-    p.as = as.toJs
-    p.additionLabel = additionLabel.map {
-      (_: Any) match {
-        case b: String => b
-        case b: Byte   => b
-        case b: Short  => b
-        case b: Int    => b
-        case b: Float  => b
-        case b: Double => b
-        case b: VdomNode =>
-          b.rawNode.asInstanceOf[RawAdditionLabel]
+    as.toJs.foreach(v => p.as = v)
+    additionLabel
+      .map[JsNumber | String | SemanticShorthandContent] {
+        (_: Any) match {
+          case b: String => b
+          case b: Byte   => b
+          case b: Short  => b
+          case b: Int    => b
+          case b: Float  => b
+          case b: Double => b
+          case b: VdomNode =>
+            b.rawNode.asInstanceOf[RawAdditionLabel]
+        }
       }
-    }
-    p.additionPosition     = additionPosition.toJs
-    p.allowAdditions       = allowAdditions
-    p.basic                = basic
-    p.button               = button
-    p.className            = (className, clazz).toJs
-    p.clearable            = clearable
-    p.closeOnBlur          = closeOnBlur
-    p.closeOnEscape        = closeOnEscape
-    p.closeOnChange        = closeOnChange
-    p.compact              = compact
-    p.deburr               = deburr
-    p.defaultOpen          = defaultOpen
-    p.defaultSearchQuery   = defaultSearchQuery
-    p.defaultSelectedLabel = defaultSelectedLabel
-    p.defaultUpward        = defaultUpward
-    p.defaultValue         = defaultValue
-    p.direction            = direction.toJs
-    p.disabled             = disabled
-    p.error                = error
-    p.floating             = floating
-    p.fluid                = fluid
-    p.header               = header.toJs
-    p.icon                 = icon.toJs
-    p.inline               = inline
-    p.item                 = item
-    p.labeled              = labeled
-    p.lazyLoad             = lazyLoad
-    p.loading              = loading
-    p.minCharacters        = minCharacters
-    p.multiple             = multiple
-    p.noResultsMessage     = noResultsMessage.toJs
-    p.onAddItem            = onAddItem.toJs
-    p.onBlur               = (onBlurE, onBlur).toJs
-    p.onChange             = onChange.toJs
-    p.onClick              = (onClickE, onClick).toJs
-    p.onClose              = (onCloseE, onClose).toJs
-    p.onFocus              = (onFocusE, onFocus).toJs
-    p.onLabelClick         = (onLabelClickE, onLabelClick).toJs
-    p.onMouseDown          = (onMouseDownE, onMouseDown).toJs
-    p.onOpen               = (onOpenE, onOpen).toJs
-    p.onSearchChange = onSearchChangeE.toJs.orElse(
-      onSearchChange.map(t => (_: ReactEvent, b: DropdownOnSearchChangeData) => t(b).runNow)
-    )
-    p.onAddItem   = onAddItem.toJs
-    p.open        = open
-    p.openOnFocus = openOnFocus
-    p.options     = options.map(_.map(_.props).toJSArray)
-    p.placeholder = placeholder
-    p.pointing    = pointing.toJs
-    p.renderLabel = renderLabel.map {
-      b => (item: DropdownItem.DropdownItemProps, index: Int, defaultProps: Label.LabelProps) =>
-        b(item, index, defaultProps).runNow
-    }
-    p.scrolling = scrolling
-    p.search = search.map {
-      (_: Any) match {
-        case b: Boolean => b
-        case b =>
-          val sf = b.asInstanceOf[SearchFunction]
-          val rsf: RawSearchFunction = (l: js.Array[DropdownItem.DropdownItemProps], s: String) =>
-            sf(l.toList, s).runNow.toJSArray
-          rsf
+      .foreach(v => p.additionLabel                          = v)
+    additionPosition.toJs.foreach(v => p.additionPosition    = v)
+    allowAdditions.foreach(v => p.allowAdditions             = v)
+    basic.foreach(v => p.basic                               = v)
+    button.foreach(v => p.button                             = v)
+    (className, clazz).toJs.foreach(v => p.className         = v)
+    clearable.foreach(v => p.clearable                       = v)
+    closeOnBlur.foreach(v => p.closeOnBlur                   = v)
+    closeOnEscape.foreach(v => p.closeOnEscape               = v)
+    closeOnChange.foreach(v => p.closeOnChange               = v)
+    compact.foreach(v => p.compact                           = v)
+    deburr.foreach(v => p.deburr                             = v)
+    defaultOpen.foreach(v => p.defaultOpen                   = v)
+    defaultSearchQuery.foreach(v => p.defaultSearchQuery     = v)
+    defaultSelectedLabel.foreach(v => p.defaultSelectedLabel = v)
+    defaultUpward.foreach(v => p.defaultUpward               = v)
+    defaultValue.foreach(v => p.defaultValue                 = v)
+    direction.toJs.foreach(v => p.direction                  = v)
+    disabled.foreach(v => p.disabled                         = v)
+    error.foreach(v => p.error                               = v)
+    floating.foreach(v => p.floating                         = v)
+    fluid.foreach(v => p.fluid                               = v)
+    header.toJs.foreach(v => p.header                        = v)
+    icon.toJs.foreach(v => p.icon                            = v)
+    inline.foreach(v => p.inline                             = v)
+    item.foreach(v => p.item                                 = v)
+    labeled.foreach(v => p.labeled                           = v)
+    lazyLoad.foreach(v => p.lazyLoad                         = v)
+    loading.foreach(v => p.loading                           = v)
+    minCharacters.foreach(v => p.minCharacters               = v)
+    multiple.foreach(v => p.multiple                         = v)
+    noResultsMessage.toJs.foreach(v => p.noResultsMessage    = v)
+    onAddItem.toJs.foreach(v => p.onAddItem                  = v)
+    (onBlurE, onBlur).toJs.foreach(v => p.onBlur             = v)
+    onChangeE.toJs
+      .orElse[RawOnChange](
+        onChange.map(t => (_: ReactEvent, b: DropdownProps) => t(b).runNow)
+      )
+      .foreach(v => p.onChange                                     = v)
+    (onClickE, onClick).toJs.foreach(v => p.onClick                = v)
+    (onCloseE, onClose).toJs.foreach(v => p.onClose                = v)
+    (onFocusE, onFocus).toJs.foreach(v => p.onFocus                = v)
+    (onLabelClickE, onLabelClick).toJs.foreach(v => p.onLabelClick = v)
+    (onMouseDownE, onMouseDown).toJs.foreach(v => p.onMouseDown    = v)
+    (onOpenE, onOpen).toJs.foreach(v => p.onOpen                   = v)
+    onSearchChangeE.toJs
+      .orElse[RawOnSearchChange](
+        onSearchChange.map(t => (_: ReactEvent, b: DropdownOnSearchChangeData) => t(b).runNow)
+      )
+      .foreach(v => p.onSearchChange                             = v)
+    onAddItem.toJs.foreach(v => p.onAddItem                      = v)
+    open.foreach(v => p.open                                     = v)
+    openOnFocus.foreach(v => p.openOnFocus                       = v)
+    options.map(_.map(_.props).toJSArray).foreach(v => p.options = v)
+    placeholder.foreach(v => p.placeholder                       = v)
+    pointing.toJs.foreach(v => p.pointing                        = v)
+    renderLabel
+      .map[RawRenderLabel] {
+        b => (item: DropdownItem.DropdownItemProps, index: Int, defaultProps: Label.LabelProps) =>
+          b(item, index, defaultProps).runNow
       }
-    }
-    p.searchInput        = searchInput.toJs
-    p.searchQuery        = searchQuery
-    p.selectOnBlur       = selectOnBlur
-    p.selectOnNavigation = selectOnNavigation
-    p.selectedLabel      = selectedLabel
-    p.selection          = selection
-    p.simple             = simple
-    p.tabIndex           = tabIndex
-    p.text               = text
-    p.trigger            = trigger.toJs
-    p.value              = value
-    p.upward             = upward
-    p.wrapSelection      = wrapSelection
+      .foreach(v => p.renderLabel      = v)
+    scrolling.foreach(v => p.scrolling = v)
+    search
+      .map[Boolean | RawSearchFunction] {
+        (_: Any) match {
+          case b: Boolean => b
+          case b =>
+            val sf = b.asInstanceOf[SearchFunction]
+            val rsf: RawSearchFunction = (l: js.Array[DropdownItem.DropdownItemProps], s: String) =>
+              sf(l.toList, s).runNow.toJSArray
+            rsf
+        }
+      }
+      .foreach(v => p.search                             = v)
+    searchInput.toJs.foreach(v => p.searchInput          = v)
+    searchQuery.foreach(v => p.searchQuery               = v)
+    selectOnBlur.foreach(v => p.selectOnBlur             = v)
+    selectOnNavigation.foreach(v => p.selectOnNavigation = v)
+    selectedLabel.foreach(v => p.selectedLabel           = v)
+    selection.foreach(v => p.selection                   = v)
+    simple.foreach(v => p.simple                         = v)
+    tabIndex.foreach(v => p.tabIndex                     = v)
+    text.foreach(v => p.text                             = v)
+    trigger.toJs.foreach(v => p.trigger                  = v)
+    value.foreach(v => p.value                           = v)
+    upward.foreach(v => p.upward                         = v)
+    wrapSelection.foreach(v => p.wrapSelection           = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownDivider.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownDivider.scala
@@ -51,8 +51,8 @@ object DropdownDivider {
     clazz:     js.UndefOr[Css]    = js.undefined
   ): DropdownDividerProps = {
     val p = as.toJsObject[DropdownDividerProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownHeader.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownHeader.scala
@@ -70,10 +70,10 @@ object DropdownHeader {
     icon:      js.UndefOr[ShorthandS[Icon]]     = js.undefined
   ): DropdownHeaderProps = {
     val p = as.toJsObject[DropdownHeaderProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
-    p.icon      = icon.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    icon.toJs.foreach(v => p.icon                    = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownItem.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownItem.scala
@@ -119,20 +119,20 @@ object DropdownItem {
     q: DropdownItem
   ): DropdownItemProps = {
     val p = q.as.toJsObject[DropdownItemProps]
-    p.as          = q.as.toJs
-    p.active      = q.active
-    p.className   = (q.className, q.clazz).toJs
-    p.content     = q.content.toJs
-    p.description = q.description
-    p.disable     = q.disable
-    p.flag        = q.flag.toJs
-    p.icon        = q.icon.toJs
-    p.image       = q.image.toJs
-    p.label       = q.label.toJs
-    p.onClick     = (q.onClickE, q.onClick).toJs
-    p.selected    = q.selected
-    p.text        = q.text
-    p.value       = q.value
+    q.as.toJs.foreach(v => p.as                          = v)
+    q.active.foreach(v => p.active                       = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.description.foreach(v => p.description             = v)
+    q.disable.foreach(v => p.disable                     = v)
+    q.flag.toJs.foreach(v => p.flag                      = v)
+    q.icon.toJs.foreach(v => p.icon                      = v)
+    q.image.toJs.foreach(v => p.image                    = v)
+    q.label.toJs.foreach(v => p.label                    = v)
+    (q.onClickE, q.onClick).toJs.foreach(v => p.onClick  = v)
+    q.selected.foreach(v => p.selected                   = v)
+    q.text.foreach(v => p.text                           = v)
+    q.value.foreach(v => p.value                         = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownMenu.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownMenu.scala
@@ -76,12 +76,12 @@ object DropdownMenu {
     scrolling: js.UndefOr[Boolean]       = js.undefined
   ): DropdownMenuProps = {
     val p = as.toJsObject[DropdownMenuProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
-    p.direction = direction.toJs
-    p.open      = open
-    p.scrolling = scrolling
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    direction.toJs.foreach(v => p.direction          = v)
+    open.foreach(v => p.open                         = v)
+    scrolling.foreach(v => p.scrolling               = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownSearchInput.scala
+++ b/facade/src/main/scala/react/semanticui/modules/dropdown/DropdownSearchInput.scala
@@ -70,12 +70,12 @@ object DropdownSearchInput {
     value:        js.UndefOr[JsNumber | String] = js.undefined
   ): DropdownSearchInputProps = {
     val p = as.toJsObject[DropdownSearchInputProps]
-    p.as           = as.toJs
-    p.autoComplete = autoComplete
-    p.className    = (className, clazz).toJs
-    p.tabIndex     = tabIndex
-    p.`type`       = `type`
-    p.value        = value
+    as.toJs.foreach(v => p.as                        = v)
+    autoComplete.foreach(v => p.autoComplete         = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    tabIndex.foreach(v => p.tabIndex                 = v)
+    p.`type` = `type`
+    value.foreach(v => p.value = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/modal/Modal.scala
+++ b/facade/src/main/scala/react/semanticui/modules/modal/Modal.scala
@@ -233,26 +233,28 @@ object Modal {
     trigger:              js.UndefOr[VdomNode]                 = js.undefined
   ): ModalProps = {
     val p = as.toJsObject[ModalProps]
-    p.as                   = as.toJs
-    p.actions              = actions.toJs
-    p.basic                = basic
-    p.centered             = centered
-    p.className            = (className, clazz).toJs
-    p.closeIcon            = closeIcon.map(_.props)
-    p.closeOnDimmerClick   = closeOnDimmerClick
-    p.closeOnDocumentClick = closeOnDocumentClick
-    p.content              = content.toJs
-    p.defaultOpen          = defaultOpen
-    p.dimmer               = dimmer.toJs
-    p.eventPool            = eventPool
-    p.header               = header.toJs
-    p.onActionClick        = (onActionClickE, onActionClick).toJs
-    p.onClose              = (onCloseE, onClose).toJs
-    p.onMount              = (onMountE, onMount).toJs.map(f => (_, p: Modal.ModalProps) => f(p))
-    p.open                 = open
-    p.size                 = size.toJs
-    p.style                = style.map(_.toJsObject)
-    p.trigger              = trigger.toJs
+    as.toJs.foreach(v => p.as                                         = v)
+    actions.toJs.foreach(v => p.actions                               = v)
+    basic.foreach(v => p.basic                                        = v)
+    centered.foreach(v => p.centered                                  = v)
+    (className, clazz).toJs.foreach(v => p.className                  = v)
+    closeIcon.map(_.props).foreach(v => p.closeIcon                   = v)
+    closeOnDimmerClick.foreach(v => p.closeOnDimmerClick              = v)
+    closeOnDocumentClick.foreach(v => p.closeOnDocumentClick          = v)
+    content.toJs.foreach(v => p.content                               = v)
+    defaultOpen.foreach(v => p.defaultOpen                            = v)
+    dimmer.toJs.foreach(v => p.dimmer                                 = v)
+    eventPool.foreach(v => p.eventPool                                = v)
+    header.toJs.foreach(v => p.header                                 = v)
+    (onActionClickE, onActionClick).toJs.foreach(v => p.onActionClick = v)
+    (onCloseE, onClose).toJs.foreach(v => p.onClose                   = v)
+    (onMountE, onMount).toJs
+      .map[RawOnMount](f => (_, p: Modal.ModalProps) => f(p))
+      .foreach(v => p.onMount                    = v)
+    open.foreach(v => p.open                     = v)
+    size.toJs.foreach(v => p.size                = v)
+    style.map(_.toJsObject).foreach(v => p.style = v)
+    trigger.toJs.foreach(v => p.trigger          = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/modal/ModalActions.scala
+++ b/facade/src/main/scala/react/semanticui/modules/modal/ModalActions.scala
@@ -80,11 +80,11 @@ object ModalActions {
     onActionClick:  js.UndefOr[Callback]                = js.undefined
   ): ModalActionsProps = {
     val p = as.toJsObject[ModalActionsProps]
-    p.as            = as.toJs
-    p.actions       = actions.toJs
-    p.className     = (className, clazz).toJs
-    p.content       = content.toJs
-    p.onActionClick = (onActionClickE, onActionClick).toJs
+    as.toJs.foreach(v => p.as                                         = v)
+    actions.toJs.foreach(v => p.actions                               = v)
+    (className, clazz).toJs.foreach(v => p.className                  = v)
+    content.toJs.foreach(v => p.content                               = v)
+    (onActionClickE, onActionClick).toJs.foreach(v => p.onActionClick = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/modal/ModalContent.scala
+++ b/facade/src/main/scala/react/semanticui/modules/modal/ModalContent.scala
@@ -71,11 +71,11 @@ object ModalContent {
     scrolling: js.UndefOr[Boolean]              = js.undefined
   ): ModalContentProps = {
     val p = as.toJsObject[ModalContentProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
-    p.image     = image
-    p.scrolling = scrolling
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    image.foreach(v => p.image                       = v)
+    scrolling.foreach(v => p.scrolling               = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/modal/ModalDescription.scala
+++ b/facade/src/main/scala/react/semanticui/modules/modal/ModalDescription.scala
@@ -61,9 +61,9 @@ object ModalDescription {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): ModalDescriptionProps = {
     val p = as.toJsObject[ModalDescriptionProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/modal/ModalHeader.scala
+++ b/facade/src/main/scala/react/semanticui/modules/modal/ModalHeader.scala
@@ -61,9 +61,9 @@ object ModalHeader {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): ModalHeaderProps = {
     val p = as.toJsObject[ModalHeaderProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/popup/Popup.scala
+++ b/facade/src/main/scala/react/semanticui/modules/popup/Popup.scala
@@ -226,32 +226,33 @@ object Popup {
     wide:            js.UndefOr[PopupWide]                = js.undefined
   ): PopupProps = {
     val p = as.toJsObject[PopupProps]
-    p.as           = as.toJs
-    p.basic        = basic
-    p.className    = (className, clazz).toJs
-    p.content      = content.toJs
-    p.disabled     = disabled
-    p.flowing      = flowing
-    p.header       = header.toJs
-    p.hideOnScroll = hideOnScroll
-    p.hoverable    = hoverable
-    p.inverted     = inverted
-    p.offset       = offset
-    p.on = on.map { x =>
-      (x: Any) match {
-        case p: PopupOn => p.toJs
-        case p          => p.asInstanceOf[List[PopupOn]].map(_.toJs).toJSArray
+    as.toJs.foreach(v => p.as                        = v)
+    basic.foreach(v => p.basic                       = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    disabled.foreach(v => p.disabled                 = v)
+    flowing.foreach(v => p.flowing                   = v)
+    header.toJs.foreach(v => p.header                = v)
+    hideOnScroll.foreach(v => p.hideOnScroll         = v)
+    hoverable.foreach(v => p.hoverable               = v)
+    inverted.foreach(v => p.inverted                 = v)
+    offset.foreach(v => p.offset                     = v)
+    on.map[String | js.Array[String]] { x =>
+        (x: Any) match {
+          case p: PopupOn => p.toJs
+          case p          => p.asInstanceOf[List[PopupOn]].map(_.toJs).toJSArray
+        }
       }
-    }
-    p.onClose         = (onCloseE, onClose).toJs
-    p.onOpen          = (onOpenE, onOpen).toJs
-    p.pinned          = pinned
-    p.position        = position.toJs
-    p.popperModifiers = popperModifiers
-    p.size            = size.toJs
-    p.style           = style.map(_.toJsObject)
-    p.trigger         = trigger.toJs
-    p.wide            = wide.toJs
+      .foreach(v => p.on                            = v)
+    (onCloseE, onClose).toJs.foreach(v => p.onClose = v)
+    (onOpenE, onOpen).toJs.foreach(v => p.onOpen    = v)
+    pinned.foreach(v => p.pinned                    = v)
+    position.toJs.foreach(v => p.position           = v)
+    popperModifiers.foreach(v => p.popperModifiers  = v)
+    size.toJs.foreach(v => p.size                   = v)
+    style.map(_.toJsObject).foreach(v => p.style    = v)
+    trigger.toJs.foreach(v => p.trigger             = v)
+    wide.toJs.foreach(v => p.wide                   = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/popup/PopupContent.scala
+++ b/facade/src/main/scala/react/semanticui/modules/popup/PopupContent.scala
@@ -61,9 +61,9 @@ object PopupContent {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): PopupContentProps = {
     val p = as.toJsObject[PopupContentProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/popup/PopupHeader.scala
+++ b/facade/src/main/scala/react/semanticui/modules/popup/PopupHeader.scala
@@ -61,9 +61,9 @@ object PopupHeader {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): PopupHeaderProps = {
     val p = as.toJsObject[PopupHeaderProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/progress/Progress.scala
+++ b/facade/src/main/scala/react/semanticui/modules/progress/Progress.scala
@@ -172,25 +172,25 @@ object Progress {
     warning:     js.UndefOr[Boolean]              = js.undefined
   ): ProgressProps = {
     val p = as.toJsObject[ProgressProps]
-    p.as          = as.toJs
-    p.active      = active
-    p.attached    = attached
-    p.autoSuccess = autoSuccess
-    p.className   = (className, clazz).toJs
-    p.color       = color.toJs
-    p.content     = content.toJs
-    p.error       = error
-    p.indicating  = indicating
-    p.inverted    = inverted
-    p.label       = label.toJs
-    p.percent     = percent
-    p.precision   = precision
-    p.progress    = progress
-    p.size        = size.toJs
-    p.success     = success
-    p.total       = total
-    p.value       = value
-    p.warning     = warning
+    as.toJs.foreach(v => p.as                        = v)
+    active.foreach(v => p.active                     = v)
+    attached.foreach(v => p.attached                 = v)
+    autoSuccess.foreach(v => p.autoSuccess           = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    color.toJs.foreach(v => p.color                  = v)
+    content.toJs.foreach(v => p.content              = v)
+    error.foreach(v => p.error                       = v)
+    indicating.foreach(v => p.indicating             = v)
+    inverted.foreach(v => p.inverted                 = v)
+    label.toJs.foreach(v => p.label                  = v)
+    percent.foreach(v => p.percent                   = v)
+    precision.foreach(v => p.precision               = v)
+    progress.foreach(v => p.progress                 = v)
+    size.toJs.foreach(v => p.size                    = v)
+    success.foreach(v => p.success                   = v)
+    total.foreach(v => p.total                       = v)
+    value.foreach(v => p.value                       = v)
+    warning.foreach(v => p.warning                   = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/sidebar/Sidebar.scala
+++ b/facade/src/main/scala/react/semanticui/modules/sidebar/Sidebar.scala
@@ -97,18 +97,18 @@ object Sidebar {
     width:     js.UndefOr[SidebarWidth]     = js.undefined
   ): SidebarProps = {
     val p = as.toJsObject[SidebarProps]
-    p.as        = as.toJs
-    p.animation = animation.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
-    p.direction = direction.toJs
-    p.onHide    = (onHideE, onHide).toJs
-    p.onHidden  = onHidden.toJs
-    p.onShow    = onShow.toJs
-    p.onVisible = onVisible.toJs
-    p.target    = target
-    p.visible   = visible
-    p.width     = width.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    animation.toJs.foreach(v => p.animation          = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    direction.toJs.foreach(v => p.direction          = v)
+    (onHideE, onHide).toJs.foreach(v => p.onHide     = v)
+    onHidden.toJs.foreach(v => p.onHidden            = v)
+    onShow.toJs.foreach(v => p.onShow                = v)
+    onVisible.toJs.foreach(v => p.onVisible          = v)
+    target.foreach(v => p.target                     = v)
+    visible.foreach(v => p.visible                   = v)
+    width.toJs.foreach(v => p.width                  = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/sidebar/SidebarPushable.scala
+++ b/facade/src/main/scala/react/semanticui/modules/sidebar/SidebarPushable.scala
@@ -51,9 +51,9 @@ object SidebarPushable {
     content:   js.UndefOr[VdomNode] = js.undefined
   ): SidebarPushableProps = {
     val p = as.toJsObject[SidebarPushableProps]
-    p.as        = as.toJs
-    p.className = className
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as           = v)
+    className.foreach(v => p.className  = v)
+    content.toJs.foreach(v => p.content = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/sidebar/SidebarPusher.scala
+++ b/facade/src/main/scala/react/semanticui/modules/sidebar/SidebarPusher.scala
@@ -54,10 +54,10 @@ object SidebarPusher {
     dimmed:    js.UndefOr[Boolean]  = js.undefined
   ): SidebarPusherProps = {
     val p = as.toJsObject[SidebarPusherProps]
-    p.as        = as.toJs
-    p.className = className
-    p.content   = content.map(_.rawNode)
-    p.dimmed    = dimmed
+    as.toJs.foreach(v => p.as                     = v)
+    className.foreach(v => p.className            = v)
+    content.map(_.rawNode).foreach(v => p.content = v)
+    dimmed.foreach(v => p.dimmed                  = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/tab/Tab.scala
+++ b/facade/src/main/scala/react/semanticui/modules/tab/Tab.scala
@@ -62,19 +62,22 @@ object Tab {
   object RawPane {
     def fromPane(q: Pane): RawPane = {
       val p = (new js.Object()).asInstanceOf[RawPane]
-      p.pane = q.pane.map(_.props)
-      p.menuItem = q.menuItem.map(d =>
-        (d: Any) match {
-          case s: String   => s
-          case m: MenuItem => m.props
+      q.pane.map(_.props).foreach(v => p.pane = v)
+      q.menuItem
+        .map[String | MenuItem.MenuItemProps](d =>
+          (d: Any) match {
+            case s: String   => s
+            case m: MenuItem => m.props
+          }
+        )
+        .foreach(v => p.menuItem = v)
+      q.render
+        .map { f =>
+          val r: js.Function0[React.Node] = f
+          r
         }
-      )
-      p.render = q.render.map { f =>
-        val r: js.Function0[React.Node] = f
-        r
-      }
+        .foreach(v => p.render = v)
       p
-
     }
   }
 
@@ -142,17 +145,18 @@ object Tab {
     q: Tab
   ): TabProps = {
     val p = q.as.toJsObject[TabProps]
-    p.as                 = q.as.toJs
-    p.defaultActiveIndex = q.defaultActiveIndex
-    p.activeIndex        = q.activeIndex
-    p.menu               = q.menu.map(_.props)
-    p.menuPosition       = q.menuPosition.toJs
-    p.grid               = q.grid.map(_.props)
-    p.onTabChange = q.onTabChangeE.toJs
-      .orElse(q.onTabChange.map(t => (_: ReactEvent, b: TabProps) => t(b).runNow))
-    p.panes            = q.panes.map(RawPane.fromPane(_)).toJSArray
-    p.renderActiveOnly = q.renderActiveOnly
-    p.vertical         = q.vertical
+    q.as.toJs.foreach(v => p.as                            = v)
+    q.defaultActiveIndex.foreach(v => p.defaultActiveIndex = v)
+    q.activeIndex.foreach(v => p.activeIndex               = v)
+    q.menu.map(_.props).foreach(v => p.menu                = v)
+    q.menuPosition.toJs.foreach(v => p.menuPosition        = v)
+    q.grid.map(_.props).foreach(v => p.grid                = v)
+    q.onTabChangeE.toJs
+      .orElse[RawOnTabChange](q.onTabChange.map(t => (_: ReactEvent, b: TabProps) => t(b).runNow))
+      .foreach(v => p.onTabChange = v)
+    p.panes = q.panes.map(RawPane.fromPane(_)).toJSArray
+    q.renderActiveOnly.foreach(v => p.renderActiveOnly = v)
+    q.vertical.foreach(v => p.vertical                 = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/modules/tab/TabPane.scala
+++ b/facade/src/main/scala/react/semanticui/modules/tab/TabPane.scala
@@ -64,11 +64,11 @@ object TabPane {
     q: TabPane
   ): TabPaneProps = {
     val p = q.as.toJsObject[TabPaneProps]
-    p.as        = q.as.toJs
-    p.active    = q.active
-    p.className = (q.className, q.clazz).toJs
-    p.content   = q.content.toJs
-    p.loading   = q.loading
+    q.as.toJs.foreach(v => p.as                          = v)
+    q.active.foreach(v => p.active                       = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.loading.foreach(v => p.loading                     = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/toasts/SemanticToastContainer.scala
+++ b/facade/src/main/scala/react/semanticui/toasts/SemanticToastContainer.scala
@@ -60,9 +60,9 @@ object SemanticToastContainer {
     clazz:     js.UndefOr[Css]               = js.undefined
   ): SemanticToastContainerProps = {
     val p = (new js.Object).asInstanceOf[SemanticToastContainerProps]
-    p.position  = position.toJs
-    p.animation = animation.toJs
-    p.className = (className, clazz).toJs
+    position.toJs.foreach(v => p.position            = v)
+    animation.toJs.foreach(v => p.animation          = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/toasts/package.scala
+++ b/facade/src/main/scala/react/semanticui/toasts/package.scala
@@ -146,17 +146,19 @@ package toasts {
     ): ToastOptions = {
 
       val p = (new js.Object).asInstanceOf[ToastOptions]
-      p.title       = title
-      p.description = description
-      p.`type`      = tpe.toJs
-      p.icon        = icon.toJs
-      p.time = time.map(_ match {
-        case Dismissal.User  => 0
-        case Dismissal.On(t) => t.toMillis.toDouble
-      })
-      p.animation = animation.toJs
-      p.size      = size.toJs
-      p.color     = color.toJs
+      p.title = title
+      description.foreach(v => p.description = v)
+      p.`type` = tpe.toJs
+      icon.toJs.foreach(v => p.icon = v)
+      time
+        .map(_ match {
+          case Dismissal.User  => 0
+          case Dismissal.On(t) => t.toMillis.toDouble
+        })
+        .foreach(v => p.time                  = v)
+      animation.toJs.foreach(v => p.animation = v)
+      size.toJs.foreach(v => p.size           = v)
+      color.toJs.foreach(v => p.color         = v)
       p
     }
   }

--- a/facade/src/main/scala/react/semanticui/views/item/Item.scala
+++ b/facade/src/main/scala/react/semanticui/views/item/Item.scala
@@ -95,14 +95,14 @@ object Item {
     meta:        js.UndefOr[ShorthandS[ItemMeta]]        = js.undefined
   ): ItemProps = {
     val p = as.toJsObject[ItemProps]
-    p.as          = as.toJs
-    p.className   = (className, clazz).toJs
-    p.content     = content.toJs
-    p.description = description.toJs
-    p.extra       = extra.toJs
-    p.header      = header.toJs
-    p.image       = image.toJs
-    p.meta        = meta.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    description.toJs.foreach(v => p.description      = v)
+    extra.toJs.foreach(v => p.extra                  = v)
+    header.toJs.foreach(v => p.header                = v)
+    image.toJs.foreach(v => p.image                  = v)
+    meta.toJs.foreach(v => p.meta                    = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/views/item/ItemContent.scala
+++ b/facade/src/main/scala/react/semanticui/views/item/ItemContent.scala
@@ -95,14 +95,14 @@ object ItemContent {
     verticalAlign: js.UndefOr[SemanticVerticalAlignment]   = js.undefined
   ): ItemContentProps = {
     val p = as.toJsObject[ItemContentProps]
-    p.as            = as.toJs
-    p.className     = (className, clazz).toJs
-    p.content       = content.toJs
-    p.description   = description.toJs
-    p.extra         = extra.toJs
-    p.header        = header.toJs
-    p.meta          = meta.toJs
-    p.verticalAlign = verticalAlign.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
+    description.toJs.foreach(v => p.description      = v)
+    extra.toJs.foreach(v => p.extra                  = v)
+    header.toJs.foreach(v => p.header                = v)
+    meta.toJs.foreach(v => p.meta                    = v)
+    verticalAlign.toJs.foreach(v => p.verticalAlign  = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/views/item/ItemDescription.scala
+++ b/facade/src/main/scala/react/semanticui/views/item/ItemDescription.scala
@@ -61,9 +61,9 @@ object ItemDescription {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): ItemDescriptionProps = {
     val p = as.toJsObject[ItemDescriptionProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/views/item/ItemExtra.scala
+++ b/facade/src/main/scala/react/semanticui/views/item/ItemExtra.scala
@@ -61,9 +61,9 @@ object ItemExtra {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): ItemExtraProps = {
     val p = as.toJsObject[ItemExtraProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/views/item/ItemGroup.scala
+++ b/facade/src/main/scala/react/semanticui/views/item/ItemGroup.scala
@@ -96,14 +96,14 @@ object ItemGroup {
     unstackable: js.UndefOr[Boolean]     = js.undefined
   ): ItemGroupProps = {
     val p = as.toJsObject[ItemGroupProps]
-    p.as          = as.toJs
-    p.className   = (className, clazz).toJs
-    p.content     = content.toJs
-    p.divided     = divided
-    p.items       = items.map(_.map(_.props).toJSArray)
-    p.link        = link
-    p.relaxed     = relaxed.toJs
-    p.unstackable = unstackable
+    as.toJs.foreach(v => p.as                                = v)
+    (className, clazz).toJs.foreach(v => p.className         = v)
+    content.toJs.foreach(v => p.content                      = v)
+    divided.foreach(v => p.divided                           = v)
+    items.map(_.map(_.props).toJSArray).foreach(v => p.items = v)
+    link.foreach(v => p.link                                 = v)
+    relaxed.toJs.foreach(v => p.relaxed                      = v)
+    unstackable.foreach(v => p.unstackable                   = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/views/item/ItemHeader.scala
+++ b/facade/src/main/scala/react/semanticui/views/item/ItemHeader.scala
@@ -61,9 +61,9 @@ object ItemHeader {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): ItemHeaderProps = {
     val p = as.toJsObject[ItemHeaderProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/views/item/ItemImage.scala
+++ b/facade/src/main/scala/react/semanticui/views/item/ItemImage.scala
@@ -59,28 +59,28 @@ object ItemImage {
     q: ItemImage
   ): ItemImageProps = {
     val p = q.as.toJsObject[ItemImageProps]
-    p.as            = q.as.toJs
-    p.avatar        = q.avatar
-    p.bordered      = q.bordered
-    p.centered      = q.centered
-    p.circular      = q.circular
-    p.className     = (q.className, q.clazz).toJs
-    p.content       = q.content.toJs
-    p.disabled      = q.disabled
-    p.dimmer        = q.dimmer.map(_.props)
-    p.floated       = q.floated.toJs
-    p.fluid         = q.fluid
-    p.hidden        = q.hidden
-    p.href          = q.href
-    p.inline        = q.inline
-    p.label         = q.label.toJs
-    p.rounded       = q.rounded
-    p.size          = q.size.toJs
-    p.spaced        = q.spaced.toJs
-    p.src           = q.src
-    p.ui            = q.ui
-    p.verticalAlign = q.verticalAlign.toJs
-    p.wrapped       = q.wrapped
+    q.as.toJs.foreach(v => p.as                          = v)
+    q.avatar.foreach(v => p.avatar                       = v)
+    q.bordered.foreach(v => p.bordered                   = v)
+    q.centered.foreach(v => p.centered                   = v)
+    q.circular.foreach(v => p.circular                   = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content                = v)
+    q.disabled.foreach(v => p.disabled                   = v)
+    q.dimmer.map(_.props).foreach(v => p.dimmer          = v)
+    q.floated.toJs.foreach(v => p.floated                = v)
+    q.fluid.foreach(v => p.fluid                         = v)
+    q.hidden.foreach(v => p.hidden                       = v)
+    q.href.foreach(v => p.href                           = v)
+    q.inline.foreach(v => p.inline                       = v)
+    q.label.toJs.foreach(v => p.label                    = v)
+    q.rounded.foreach(v => p.rounded                     = v)
+    q.size.toJs.foreach(v => p.size                      = v)
+    q.spaced.toJs.foreach(v => p.spaced                  = v)
+    q.src.foreach(v => p.src                             = v)
+    q.ui.foreach(v => p.ui                               = v)
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign    = v)
+    q.wrapped.foreach(v => p.wrapped                     = v)
     p
   }
 

--- a/facade/src/main/scala/react/semanticui/views/item/ItemMeta.scala
+++ b/facade/src/main/scala/react/semanticui/views/item/ItemMeta.scala
@@ -61,9 +61,9 @@ object ItemMeta {
     content:   js.UndefOr[ShorthandS[VdomNode]] = js.undefined
   ): ItemMetaProps = {
     val p = as.toJsObject[ItemMetaProps]
-    p.as        = as.toJs
-    p.className = (className, clazz).toJs
-    p.content   = content.toJs
+    as.toJs.foreach(v => p.as                        = v)
+    (className, clazz).toJs.foreach(v => p.className = v)
+    content.toJs.foreach(v => p.content              = v)
     p
   }
 

--- a/facade/src/test/scala/react/semanticui/elements/button/ButtonTests.scala
+++ b/facade/src/test/scala/react/semanticui/elements/button/ButtonTests.scala
@@ -87,8 +87,9 @@ object ButtonTests extends TestSuite {
     test("label") {
       val button = Button(label = Label("Label"))
       ReactTestUtils.withRenderedIntoDocument(button) { m =>
+        val html = m.outerHtmlScrubbed()
         assert(
-          m.outerHtmlScrubbed() == """<div class="ui labeled button"><button class="ui button" tabindex="0"> </button><div class="ui label">Label</div></div>"""
+          html == """<div class="ui labeled button"><button class="ui button" tabindex="0"> </button><div class="ui left pointing basic label">Label</div></div>"""
         )
       }
     }

--- a/facade/src/test/scala/react/semanticui/modules/dropdown/DropdownTests.scala
+++ b/facade/src/test/scala/react/semanticui/modules/dropdown/DropdownTests.scala
@@ -16,19 +16,19 @@ object DropdownTests extends TestSuite {
     }
     test("options") {
       val options =
-        List(DropdownItem("abc"), DropdownItem(text = "def", value = 2, selected = true))
+        List(DropdownItem("abc"), DropdownItem(text = "def", value = 2))
       val dropdown = Dropdown(options = options)
       ReactTestUtils.withNewBodyElement { mountNode =>
         dropdown.renderIntoDOM(mountNode)
         val html = mountNode.outerHTML
         assert(
-          html == """<div><div role="listbox" aria-expanded="false" class="ui dropdown" tabindex="0"><div class="text" role="alert" aria-live="polite" aria-atomic="true"></div><i aria-hidden="true" class="dropdown icon"></i><div class="menu transition"><div style="pointer-events: all;" role="option" class="item">abc</div><div style="pointer-events: all;" role="option" aria-selected="true" class="selected item"><span class="text">def</span></div></div></div></div>"""
+          html == """<div><div role="listbox" aria-expanded="false" class="ui dropdown" tabindex="0"><div class="text" role="alert" aria-live="polite" aria-atomic="true"></div><i aria-hidden="true" class="dropdown icon"></i><div class="menu transition"><div style="pointer-events: all;" role="option" aria-checked="false" aria-selected="true" class="selected item">abc</div><div style="pointer-events: all;" role="option" aria-checked="false" aria-selected="false" class="item"><span class="text">def</span></div></div></div></div>"""
         )
       }
     }
     test("additionLabel") {
       val options =
-        List(DropdownItem("abc"), DropdownItem(text = "def", value = 2, selected = true))
+        List(DropdownItem("abc"), DropdownItem(text = "def", value = 2))
       val dropdown = Dropdown(options = options,
                               selection        = false,
                               search           = true,
@@ -40,7 +40,7 @@ object DropdownTests extends TestSuite {
         dropdown.renderIntoDOM(mountNode)
         val html = mountNode.outerHTML
         assert(
-          html == """<div><div role="combobox" aria-expanded="true" class="ui active visible search dropdown"><input aria-autocomplete="list" autocomplete="off" class="search" tabindex="0" type="text" value=""><div class="text" role="alert" aria-live="polite" aria-atomic="true"></div><i aria-hidden="true" class="dropdown icon"></i><div role="listbox" class="visible menu transition"><div style="pointer-events: all;" role="option" class="item">abc</div><div style="pointer-events: all;" role="option" aria-selected="true" class="selected item"><span class="text">def</span></div></div></div></div>"""
+          html == """<div><div role="combobox" aria-expanded="true" class="ui active visible search dropdown"><input aria-autocomplete="list" autocomplete="off" class="search" tabindex="0" type="text" value=""><div class="text" role="alert" aria-live="polite" aria-atomic="true"></div><i aria-hidden="true" class="dropdown icon"></i><div role="listbox" class="visible menu transition"><div style="pointer-events: all;" role="option" aria-checked="false" aria-selected="true" class="selected item">abc</div><div style="pointer-events: all;" role="option" aria-checked="false" aria-selected="false" class="item"><span class="text">def</span></div></div></div></div>"""
         )
       }
     }


### PR DESCRIPTION
The idea here is to avoid passing undefined properties as `undefined` and just omit them.

Turns out that by passing them as `undefined` we were preventing react-semantic-ui from applying default properties. In some cases this caused default behavior not to kick-in (eg: `Button` with `Label`) and at least in one case (`Dropdown/Select` `onChange`) it broke functionality.