### PR TITLE
Refactoring of constants encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.5.6
+
+* Change the way constants are encoded
+
 ## 0.5.4
 
 * Card components.

--- a/facade/src/main/scala/react/semanticui/colors.scala
+++ b/facade/src/main/scala/react/semanticui/colors.scala
@@ -2,24 +2,23 @@ package react.semanticui
 
 import react.common.EnumValue
 
-trait Colors {
+object colors {
   sealed trait SemanticColor extends Product with Serializable
+
   object SemanticColor {
     implicit val enum: EnumValue[SemanticColor] = EnumValue.toLowerCaseString
-    case object Red    extends SemanticColor
-    case object Orange extends SemanticColor
-    case object Yellow extends SemanticColor
-    case object Olive  extends SemanticColor
-    case object Green  extends SemanticColor
-    case object Teal   extends SemanticColor
-    case object Blue   extends SemanticColor
-    case object Violet extends SemanticColor
-    case object Purple extends SemanticColor
-    case object Pink   extends SemanticColor
-    case object Brown  extends SemanticColor
-    case object Grey   extends SemanticColor
-    case object Black  extends SemanticColor
   }
+  case object Red extends SemanticColor
+  case object Orange extends SemanticColor
+  case object Yellow extends SemanticColor
+  case object Olive  extends SemanticColor
+  case object Green  extends SemanticColor
+  case object Teal   extends SemanticColor
+  case object Blue   extends SemanticColor
+  case object Violet extends SemanticColor
+  case object Purple extends SemanticColor
+  case object Pink   extends SemanticColor
+  case object Brown  extends SemanticColor
+  case object Grey   extends SemanticColor
+  case object Black  extends SemanticColor
 }
-
-object Colors extends Colors

--- a/facade/src/main/scala/react/semanticui/floats.scala
+++ b/facade/src/main/scala/react/semanticui/floats.scala
@@ -2,13 +2,12 @@ package react.semanticui
 
 import react.common.EnumValue
 
-trait Floats {
+object floats {
+
   sealed trait SemanticFloat extends Product with Serializable
   object SemanticFloat {
     implicit val enum: EnumValue[SemanticFloat] = EnumValue.toLowerCaseString
-    case object Left  extends SemanticFloat
-    case object Right extends SemanticFloat
   }
+  case object Left extends SemanticFloat
+  case object Right extends SemanticFloat
 }
-
-object Floats extends Floats

--- a/facade/src/main/scala/react/semanticui/package.scala
+++ b/facade/src/main/scala/react/semanticui/package.scala
@@ -17,7 +17,7 @@ package semanticui {
     val props: P
   }
 
-  object As          {
+  object As               {
     import elements.segment.{ Segment => SUISegment }
     import collections.menu.{ Menu => SUIMenu }
     import collections.grid.{ Grid => SUIGrid }
@@ -147,25 +147,17 @@ package semanticui {
   }
 }
 
-package object semanticui
-    extends Floats
-    with Widths
-    with Colors
-    with Sizes
-    with TextAlignment
-    with VerticalAlignment
-    with Transitions {
+package object semanticui {
 
-  type TabIndex = Double | String
+  type SemanticWidth             = widths.SemanticWidth
+  type SemanticFloat             = floats.SemanticFloat
+  type SemanticColor             = colors.SemanticColor
+  type SemanticSize              = sizes.SemanticSize
+  type SemanticVerticalAlignment = verticalalignment.SemanticVerticalAlignment
+  type SemanticTextAlignment     = textalignment.SemanticTextAlignment
+  type SemanticTransition        = transitions.SemanticTransition
 
-  val floats            = SemanticFloat
-  val widths            = SemanticWidth
-  val colors            = SemanticColor
-  val sizes             = SemanticSize
-  val textalignment     = SemanticTextAlignment
-  val verticalalignment = SemanticVerticalAlignment
-  val transitions       = SemanticTransition
-
+  type TabIndex       = Double | String
   type ShorthandS[C]  = String | C
   type ShorthandB[C]  = Boolean | C
   type ShorthandSB[C] = String | Boolean | C

--- a/facade/src/main/scala/react/semanticui/sizes.scala
+++ b/facade/src/main/scala/react/semanticui/sizes.scala
@@ -2,19 +2,17 @@ package react.semanticui
 
 import react.common.EnumValue
 
-trait Sizes {
+object sizes {
   sealed trait SemanticSize extends Product with Serializable
   object SemanticSize {
     implicit val enum: EnumValue[SemanticSize] = EnumValue.toLowerCaseString
-    case object Mini    extends SemanticSize
-    case object Tiny    extends SemanticSize
-    case object Small   extends SemanticSize
-    case object Medium  extends SemanticSize
-    case object Large   extends SemanticSize
-    case object Big     extends SemanticSize
-    case object Huge    extends SemanticSize
-    case object Massive extends SemanticSize
   }
+  case object Mini extends SemanticSize
+  case object Tiny    extends SemanticSize
+  case object Small   extends SemanticSize
+  case object Medium  extends SemanticSize
+  case object Large   extends SemanticSize
+  case object Big     extends SemanticSize
+  case object Huge    extends SemanticSize
+  case object Massive extends SemanticSize
 }
-
-object Sizes extends Sizes

--- a/facade/src/main/scala/react/semanticui/textalignment.scala
+++ b/facade/src/main/scala/react/semanticui/textalignment.scala
@@ -2,15 +2,13 @@ package react.semanticui
 
 import react.common.EnumValue
 
-trait TextAlignment {
+object textalignment {
   sealed trait SemanticTextAlignment extends Product with Serializable
   object SemanticTextAlignment {
     implicit val enum: EnumValue[SemanticTextAlignment] = EnumValue.toLowerCaseString
-    case object Left      extends SemanticTextAlignment
-    case object Center    extends SemanticTextAlignment
-    case object Right     extends SemanticTextAlignment
-    case object Justified extends SemanticTextAlignment
   }
+  case object Left extends SemanticTextAlignment
+  case object Center    extends SemanticTextAlignment
+  case object Right     extends SemanticTextAlignment
+  case object Justified extends SemanticTextAlignment
 }
-
-object TextAlignment extends TextAlignment

--- a/facade/src/main/scala/react/semanticui/toasts/package.scala
+++ b/facade/src/main/scala/react/semanticui/toasts/package.scala
@@ -5,7 +5,6 @@ import japgolly.scalajs.react.Callback
 import react.common._
 import react.semanticui.{ raw => suiraw }
 import react.semanticui.elements.icon.Icon
-import react.semanticui.colors._
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.concurrent.duration._

--- a/facade/src/main/scala/react/semanticui/transitions.scala
+++ b/facade/src/main/scala/react/semanticui/transitions.scala
@@ -2,7 +2,7 @@ package react.semanticui
 
 import react.common.EnumValue
 
-trait Transitions {
+object transitions {
   sealed trait SemanticTransition extends Product with Serializable
   object SemanticTransition {
     implicit val enum: EnumValue[SemanticTransition] = EnumValue.instance {
@@ -39,39 +39,37 @@ trait Transitions {
       case Bounce         => "bounce"
       case Glow           => "glow"
     }
-
-    case object Browse         extends SemanticTransition
-    case object BrowseRight    extends SemanticTransition
-    case object Drop           extends SemanticTransition
-    case object Fade           extends SemanticTransition
-    case object FadeUp         extends SemanticTransition
-    case object FadeDown       extends SemanticTransition
-    case object FadeLeft       extends SemanticTransition
-    case object FadeRight      extends SemanticTransition
-    case object FlyUp          extends SemanticTransition
-    case object FlyDown        extends SemanticTransition
-    case object FlyLeft        extends SemanticTransition
-    case object FlyRight       extends SemanticTransition
-    case object HorizontalFlip extends SemanticTransition
-    case object VerticalFlip   extends SemanticTransition
-    case object Scale          extends SemanticTransition
-    case object SlideUp        extends SemanticTransition
-    case object SlideDown      extends SemanticTransition
-    case object SlideLeft      extends SemanticTransition
-    case object SlideRight     extends SemanticTransition
-    case object SwingUp        extends SemanticTransition
-    case object SwingDown      extends SemanticTransition
-    case object SwingLeft      extends SemanticTransition
-    case object SwingRight     extends SemanticTransition
-    case object Zoom           extends SemanticTransition
-    case object Jiggle         extends SemanticTransition
-    case object Flash          extends SemanticTransition
-    case object Shake          extends SemanticTransition
-    case object Pulse          extends SemanticTransition
-    case object Tada           extends SemanticTransition
-    case object Bounce         extends SemanticTransition
-    case object Glow           extends SemanticTransition
   }
-}
 
-object Transitions extends Transitions
+  case object Browse         extends SemanticTransition
+  case object BrowseRight    extends SemanticTransition
+  case object Drop           extends SemanticTransition
+  case object Fade           extends SemanticTransition
+  case object FadeUp         extends SemanticTransition
+  case object FadeDown       extends SemanticTransition
+  case object FadeLeft       extends SemanticTransition
+  case object FadeRight      extends SemanticTransition
+  case object FlyUp          extends SemanticTransition
+  case object FlyDown        extends SemanticTransition
+  case object FlyLeft        extends SemanticTransition
+  case object FlyRight       extends SemanticTransition
+  case object HorizontalFlip extends SemanticTransition
+  case object VerticalFlip   extends SemanticTransition
+  case object Scale          extends SemanticTransition
+  case object SlideUp        extends SemanticTransition
+  case object SlideDown      extends SemanticTransition
+  case object SlideLeft      extends SemanticTransition
+  case object SlideRight     extends SemanticTransition
+  case object SwingUp        extends SemanticTransition
+  case object SwingDown      extends SemanticTransition
+  case object SwingLeft      extends SemanticTransition
+  case object SwingRight     extends SemanticTransition
+  case object Zoom           extends SemanticTransition
+  case object Jiggle         extends SemanticTransition
+  case object Flash          extends SemanticTransition
+  case object Shake          extends SemanticTransition
+  case object Pulse          extends SemanticTransition
+  case object Tada           extends SemanticTransition
+  case object Bounce         extends SemanticTransition
+  case object Glow           extends SemanticTransition
+}

--- a/facade/src/main/scala/react/semanticui/verticalalignment.scala
+++ b/facade/src/main/scala/react/semanticui/verticalalignment.scala
@@ -2,14 +2,13 @@ package react.semanticui
 
 import react.common.EnumValue
 
-trait VerticalAlignment {
+object verticalalignment {
+
   sealed trait SemanticVerticalAlignment extends Product with Serializable
   object SemanticVerticalAlignment {
     implicit val enum: EnumValue[SemanticVerticalAlignment] = EnumValue.toLowerCaseString
-    case object Bottom extends SemanticVerticalAlignment
-    case object Middle extends SemanticVerticalAlignment
-    case object Top    extends SemanticVerticalAlignment
   }
+  case object Bottom extends SemanticVerticalAlignment
+  case object Middle extends SemanticVerticalAlignment
+  case object Top    extends SemanticVerticalAlignment
 }
-
-object VerticalAlignment extends VerticalAlignment

--- a/facade/src/main/scala/react/semanticui/widths.scala
+++ b/facade/src/main/scala/react/semanticui/widths.scala
@@ -4,52 +4,49 @@ import scala.scalajs.js
 import js.JSConverters._
 import react.common.EnumValue
 
-trait Widths {
+object widths {
   sealed trait SemanticWidth extends Product with Serializable
   object SemanticWidth {
     implicit val enum: EnumValue[SemanticWidth] = EnumValue.toLowerCaseString
-    case object One      extends SemanticWidth
-    case object Two      extends SemanticWidth
-    case object Three    extends SemanticWidth
-    case object Four     extends SemanticWidth
-    case object Five     extends SemanticWidth
-    case object Six      extends SemanticWidth
-    case object Seven    extends SemanticWidth
-    case object Eight    extends SemanticWidth
-    case object Nine     extends SemanticWidth
-    case object Ten      extends SemanticWidth
-    case object Eleven   extends SemanticWidth
-    case object Twelve   extends SemanticWidth
-    case object Thirteen extends SemanticWidth
-    case object Fourteen extends SemanticWidth
-    case object Fifteen  extends SemanticWidth
-    case object Sixteen  extends SemanticWidth
   }
 
-}
+  case object One      extends SemanticWidth
+  case object Two      extends SemanticWidth
+  case object Three    extends SemanticWidth
+  case object Four     extends SemanticWidth
+  case object Five     extends SemanticWidth
+  case object Six      extends SemanticWidth
+  case object Seven    extends SemanticWidth
+  case object Eight    extends SemanticWidth
+  case object Nine     extends SemanticWidth
+  case object Ten      extends SemanticWidth
+  case object Eleven   extends SemanticWidth
+  case object Twelve   extends SemanticWidth
+  case object Thirteen extends SemanticWidth
+  case object Fourteen extends SemanticWidth
+  case object Fifteen  extends SemanticWidth
+  case object Sixteen  extends SemanticWidth
 
-object Widths extends Widths {
-
-  def width(i: Int): js.UndefOr[SemanticWidth] =
+  def widthOf(i: Int): js.UndefOr[SemanticWidth] =
     allWidths.get(i).orUndefined
 
   val allWidths: Map[Int, SemanticWidth] =
     Map(
-      1  -> SemanticWidth.One,
-      2  -> SemanticWidth.Two,
-      3  -> SemanticWidth.Three,
-      4  -> SemanticWidth.Four,
-      5  -> SemanticWidth.Five,
-      6  -> SemanticWidth.Six,
-      7  -> SemanticWidth.Seven,
-      8  -> SemanticWidth.Eight,
-      9  -> SemanticWidth.Nine,
-      10 -> SemanticWidth.Ten,
-      11 -> SemanticWidth.Eleven,
-      12 -> SemanticWidth.Twelve,
-      13 -> SemanticWidth.Thirteen,
-      14 -> SemanticWidth.Fourteen,
-      15 -> SemanticWidth.Fifteen,
-      16 -> SemanticWidth.Sixteen
+      1  -> One,
+      2  -> Two,
+      3  -> Three,
+      4  -> Four,
+      5  -> Five,
+      6  -> Six,
+      7  -> Seven,
+      8  -> Eight,
+      9  -> Nine,
+      10 -> Ten,
+      11 -> Eleven,
+      12 -> Twelve,
+      13 -> Thirteen,
+      14 -> Fourteen,
+      15 -> Fifteen,
+      16 -> Sixteen
     )
 }

--- a/facade/src/test/scala/react/semanticui/elements/button/ButtonGroupTests.scala
+++ b/facade/src/test/scala/react/semanticui/elements/button/ButtonGroupTests.scala
@@ -3,6 +3,7 @@ package react.semanticui.elements.button
 import utest._
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
+import react.semanticui.widths.widthOf
 
 object ButtonGroupTests extends TestSuite {
   val tests = Tests {
@@ -11,6 +12,16 @@ object ButtonGroupTests extends TestSuite {
       ReactTestUtils.withNewBodyElement { mountNode =>
         buttonGroup.renderIntoDOM(mountNode)
         assert(mountNode.innerHTML == """<div class="ui buttons">abc</div>""")
+      }
+    }
+    test("widths") {
+      val buttonGroup =
+        ButtonGroup(widths = widthOf(2))(Button("1"), Button("2"))
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        buttonGroup.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<div class="ui two buttons"><button class="ui button">1</button><button class="ui button">2</button></div>"""
+        )
       }
     }
     test("buttons") {

--- a/facade/src/test/scala/react/semanticui/elements/button/ButtonTests.scala
+++ b/facade/src/test/scala/react/semanticui/elements/button/ButtonTests.scala
@@ -8,6 +8,7 @@ import react.semanticui.elements.label.Label
 import react.semanticui.collections.form.Form
 import react.semanticui.colors._
 import react.semanticui.sizes._
+import react.semanticui.floats._
 import react.semanticui._
 
 object ButtonTests extends TestSuite {
@@ -125,7 +126,7 @@ object ButtonTests extends TestSuite {
       }
     }
     test("floated") {
-      val button = Button(floated = SemanticFloat.Right)
+      val button = Button(floated = Right)
       ReactTestUtils.withRenderedIntoDocument(button) { m =>
         assert(m.outerHtmlScrubbed() == """<button class="ui right floated button"></button>""")
       }

--- a/facade/src/test/scala/react/semanticui/elements/rail/RailTests.scala
+++ b/facade/src/test/scala/react/semanticui/elements/rail/RailTests.scala
@@ -3,12 +3,12 @@ package react.semanticui.elements.rail
 import utest._
 import japgolly.scalajs.react.test._
 import japgolly.scalajs.react.vdom.html_<^._
-import react.semanticui._
+import react.semanticui.floats._
 
 object RailTests extends TestSuite {
   val tests = Tests {
     test("render") {
-      val rail = Rail(position = floats.Left)("abc")
+      val rail = Rail(position = Left)("abc")
       ReactTestUtils.withNewBodyElement { mountNode =>
         rail.renderIntoDOM(mountNode)
         assert(mountNode.innerHTML == """<div class="ui left rail">abc</div>""")


### PR DESCRIPTION
The way constants are encoded can be problematic as being inside a trait makes them path dependent. This PR changes it and hopefully simplifies it while making them easy to import

This may break some code though (mostly imports)