### PR TITLE
Make checkbox onChange callbacks include the state

### DIFF
--- a/facade/src/main/scala/react/semanticui/collections/form/FormCheckbox.scala
+++ b/facade/src/main/scala/react/semanticui/collections/form/FormCheckbox.scala
@@ -31,7 +31,7 @@ final case class FormCheckbox(
   inline:                 js.UndefOr[Boolean] = js.undefined,
   label:                  js.UndefOr[ShorthandS[Label]] = js.undefined,
   name:                   js.UndefOr[String] = js.undefined,
-  onChange:               js.UndefOr[Callback] = js.undefined,
+  onChange:               js.UndefOr[Boolean => Callback] = js.undefined,
   onChangeE:              js.UndefOr[Checkbox.Event] = js.undefined,
   onClick:                js.UndefOr[Callback] = js.undefined,
   onClickE:               js.UndefOr[Checkbox.Event] = js.undefined,
@@ -239,7 +239,7 @@ object FormCheckbox {
     inline:               js.UndefOr[Boolean] = js.undefined,
     label:                js.UndefOr[ShorthandS[Label]] = js.undefined,
     name:                 js.UndefOr[String] = js.undefined,
-    onChange:             js.UndefOr[Callback] = js.undefined,
+    onChange:             js.UndefOr[Boolean => Callback] = js.undefined,
     onChangeE:            js.UndefOr[Checkbox.Event] = js.undefined,
     onClick:              js.UndefOr[Callback] = js.undefined,
     onClickE:             js.UndefOr[Checkbox.Event] = js.undefined,
@@ -259,7 +259,18 @@ object FormCheckbox {
   ): FormCheckboxProps = {
     val p = as.toJsObject[FormCheckboxProps]
     (className, clazz).toJs.foreach(v => p.className = v)
-    (onChangeE, onChange).toJs.foreach(v => p.onChange = v)
+    onChangeE.toJs
+      .map(v => p.onChange = v)
+      .orElse(
+        onChange.toJs.foreach(v =>
+          p.onChange = (
+            (
+              _:  ReactMouseEvent,
+              cp: Checkbox.CheckboxProps
+            ) => cp.checked.foreach(v(_))
+          ): Checkbox.RawEvent
+        )
+      )
     (onClickE, onClick).toJs.foreach(v => p.onClick = v)
     (onMouseDownE, onMouseDown).toJs.foreach(v => p.onMouseDown = v)
     (onMouseUpE, onMouseUp).toJs.foreach(v => p.onMouseUp = v)

--- a/facade/src/main/scala/react/semanticui/modules/checkbox/Checkbox.scala
+++ b/facade/src/main/scala/react/semanticui/modules/checkbox/Checkbox.scala
@@ -25,7 +25,7 @@ final case class Checkbox(
   label:                  js.UndefOr[ShorthandS[Label]] = js.undefined,
   name:                   js.UndefOr[String] = js.undefined,
   onChangeE:              js.UndefOr[Checkbox.Event] = js.undefined,
-  onChange:               js.UndefOr[Callback] = js.undefined,
+  onChange:               js.UndefOr[Boolean => Callback] = js.undefined,
   onClickE:               js.UndefOr[Checkbox.Event] = js.undefined,
   onClick:                js.UndefOr[Callback] = js.undefined,
   onMouseDownE:           js.UndefOr[Checkbox.Event] = js.undefined,
@@ -196,7 +196,7 @@ object Checkbox {
     label:                js.UndefOr[ShorthandS[Label]] = js.undefined,
     name:                 js.UndefOr[String] = js.undefined,
     onChangeE:            js.UndefOr[Event] = js.undefined,
-    onChange:             js.UndefOr[Callback] = js.undefined,
+    onChange:             js.UndefOr[Boolean => Callback] = js.undefined,
     onClickE:             js.UndefOr[Event] = js.undefined,
     onClick:              js.UndefOr[Callback] = js.undefined,
     onMouseDownE:         js.UndefOr[Event] = js.undefined,
@@ -223,7 +223,14 @@ object Checkbox {
     indeterminate.foreach(v => p.indeterminate = v)
     label.toJs.foreach(v => p.label = v)
     name.foreach(v => p.name = v)
-    (onChangeE, onChange).toJs.foreach(v => p.onChange = v)
+    onChangeE.toJs
+      .map(v => p.onChange = v)
+      .orElse(
+        onChange.toJs.foreach(v =>
+          p.onChange =
+            ((_: ReactMouseEvent, cp: CheckboxProps) => cp.checked.foreach(v(_))): RawEvent
+        )
+      )
     (onClickE, onClick).toJs.foreach(v => p.onClick = v)
     (onMouseDownE, onMouseDown).toJs.foreach(v => p.onMouseDown = v)
     (onMouseUpE, onMouseUp).toJs.foreach(v => p.onMouseUp = v)

--- a/facade/src/test/scala/react/semanticui/modules/checkbox/CheckboxTests.scala
+++ b/facade/src/test/scala/react/semanticui/modules/checkbox/CheckboxTests.scala
@@ -2,11 +2,22 @@ package react.semanticui.modules.checkbox
 
 import utest._
 import japgolly.scalajs.react.test._
+import japgolly.scalajs.react.Callback
 
 object CheckboxTests extends TestSuite {
   val tests = Tests {
-    test("pusher") {
+    test("render") {
       val check = Checkbox()
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        check.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<div class="ui fitted checkbox"><input class="hidden" readonly="" tabindex="0" type="checkbox" value=""><label></label></div>"""
+        )
+      }
+    }
+    test("boolean callback") {
+      val cb    = (b: Boolean) => Callback.log(b)
+      val check = Checkbox(onChange = cb)
       ReactTestUtils.withNewBodyElement { mountNode =>
         check.renderIntoDOM(mountNode)
         assert(


### PR DESCRIPTION
This updates the Checkbox `onChange` callbacks to include the state of the checkbox