### PR TITLE
Switch some form control labels to allow Label as well as string.

### DIFF
--- a/facade/src/main/scala/react/semanticui/collections/form/FormDropdown.scala
+++ b/facade/src/main/scala/react/semanticui/collections/form/FormDropdown.scala
@@ -47,7 +47,7 @@ final case class FormDropdown(
   icon:                   js.UndefOr[ShorthandS[Icon]] = js.undefined,
   inline:                 js.UndefOr[Boolean] = js.undefined,
   item:                   js.UndefOr[Boolean] = js.undefined,
-  label:                  js.UndefOr[ShorthandS[String]] = js.undefined,
+  label:                  js.UndefOr[ShorthandS[Label]] = js.undefined,
   labeled:                js.UndefOr[Boolean] = js.undefined,
   lazyLoad:               js.UndefOr[Boolean] = js.undefined,
   loading:                js.UndefOr[Boolean] = js.undefined,

--- a/facade/src/main/scala/react/semanticui/collections/form/FormField.scala
+++ b/facade/src/main/scala/react/semanticui/collections/form/FormField.scala
@@ -20,7 +20,7 @@ final case class FormField(
   error:                  js.UndefOr[ShorthandB[Label]] = js.undefined,
   id:                     js.UndefOr[String] = js.undefined,
   inline:                 js.UndefOr[Boolean] = js.undefined,
-  label:                  js.UndefOr[ShorthandS[String]] = js.undefined,
+  label:                  js.UndefOr[ShorthandS[Label]] = js.undefined,
   required:               js.UndefOr[Boolean] = js.undefined,
   tpe:                    js.UndefOr[String] = js.undefined,
   width:                  js.UndefOr[SemanticWidth] = js.undefined,

--- a/facade/src/main/scala/react/semanticui/collections/form/FormSelect.scala
+++ b/facade/src/main/scala/react/semanticui/collections/form/FormSelect.scala
@@ -50,7 +50,7 @@ final case class FormSelect(
   icon:                   js.UndefOr[ShorthandS[Icon]] = js.undefined,
   inline:                 js.UndefOr[Boolean] = js.undefined,
   item:                   js.UndefOr[Boolean] = js.undefined,
-  label:                  js.UndefOr[ShorthandS[String]] = js.undefined,
+  label:                  js.UndefOr[ShorthandS[Label]] = js.undefined,
   labeled:                js.UndefOr[Boolean] = js.undefined,
   lazyLoad:               js.UndefOr[Boolean] = js.undefined,
   loading:                js.UndefOr[Boolean] = js.undefined,


### PR DESCRIPTION
A few of the Form* controls had the `label` type as `ShorthandS[String]` instead of `ShorthandS[Label]`.