### PR TITLE
Add Table facade.

### DIFF
--- a/facade/src/main/scala/react/semanticui/collections/table/Table.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/Table.scala
@@ -14,7 +14,7 @@ final case class Table(
   as:                     js.UndefOr[AsC] = js.undefined,
   attached:               js.UndefOr[TableAttached] = js.undefined,
   basic:                  js.UndefOr[TableBasic] = js.undefined,
-  celled:                 js.UndefOr[TableCelled] = js.undefined,
+  celled:                 js.UndefOr[Boolean] = js.undefined,
   className:              js.UndefOr[String] = js.undefined,
   clazz:                  js.UndefOr[Css] = js.undefined,
   collapsing:             js.UndefOr[Boolean] = js.undefined,
@@ -65,7 +65,7 @@ object Table {
     var basic: js.UndefOr[Boolean | String] = js.native
 
     /** A table may be divided each row into separate cells. */
-    var celled: js.UndefOr[Boolean | String] = js.native
+    var celled: js.UndefOr[Boolean] = js.native
 
     /** Primary content. */
     var children: js.UndefOr[React.Node] = js.native
@@ -135,7 +135,7 @@ object Table {
     q.as.toJs.foreach(v => p.as = v)
     q.attached.toJs.foreach(v => p.attached = v)
     q.basic.toJs.foreach(v => p.basic = v)
-    q.celled.toJs.foreach(v => p.celled = v)
+    q.celled.foreach(v => p.celled = v)
     (q.className, q.clazz).toJs.foreach(v => p.className = v)
     q.collapsing.foreach(v => p.collapsing = v)
     q.color.toJs.foreach(v => p.color = v)

--- a/facade/src/main/scala/react/semanticui/collections/table/Table.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/Table.scala
@@ -1,0 +1,164 @@
+package react.semanticui.collections.table
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.raw.React
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common._
+import react.semanticui.{ raw => suiraw }
+import react.semanticui._
+
+final case class Table(
+  as:                     js.UndefOr[AsC] = js.undefined,
+  attached:               js.UndefOr[TableAttached] = js.undefined,
+  basic:                  js.UndefOr[TableBasic] = js.undefined,
+  celled:                 js.UndefOr[TableCelled] = js.undefined,
+  className:              js.UndefOr[String] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  collapsing:             js.UndefOr[Boolean] = js.undefined,
+  color:                  js.UndefOr[SemanticColor] = js.undefined,
+  columns:                js.UndefOr[SemanticWidth] = js.undefined,
+  compact:                js.UndefOr[TableCompact] = js.undefined,
+  definition:             js.UndefOr[Boolean] = js.undefined,
+  fixed:                  js.UndefOr[Boolean] = js.undefined,
+  inverted:               js.UndefOr[Boolean] = js.undefined,
+  padded:                 js.UndefOr[TablePadded] = js.undefined,
+  selectable:             js.UndefOr[Boolean] = js.undefined,
+  singleLine:             js.UndefOr[Boolean] = js.undefined,
+  size:                   js.UndefOr[TableSize] = js.undefined,
+  sortable:               js.UndefOr[Boolean] = js.undefined,
+  stackable:              js.UndefOr[Boolean] = js.undefined,
+  striped:                js.UndefOr[Boolean] = js.undefined,
+  structured:             js.UndefOr[Boolean] = js.undefined,
+  textAlign:              js.UndefOr[TableTextAlign] = js.undefined,
+  unstackable:            js.UndefOr[Boolean] = js.undefined,
+  verticalAlign:          js.UndefOr[SemanticVerticalAlignment] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[Table.TableProps, Table] {
+  override protected def cprops    = Table.props((this))
+  override protected val component = Table.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
+
+object Table {
+  @js.native
+  @JSImport("semantic-ui-react", "Table")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait TableProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.native
+
+    /** Attach table to other content */
+    var attached: js.UndefOr[Boolean | String] = js.native
+
+    /** A table can reduce its complexity to increase readability. */
+    var basic: js.UndefOr[Boolean | String] = js.native
+
+    /** A table may be divided each row into separate cells. */
+    var celled: js.UndefOr[Boolean | String] = js.native
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.native
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.native
+
+    /** A table can be collapsing, taking up only as much space as its rows. */
+    var collapsing: js.UndefOr[Boolean] = js.native
+
+    /** A table can be given a color to distinguish it from other tables. */
+    var color: js.UndefOr[suiraw.SemanticCOLORS] = js.native
+
+    /** A table can specify its column count to divide its content evenly. */
+    var columns: js.UndefOr[String] = js.native
+
+    /** A table may sometimes need to be more compact to make more rows visible at a time. */
+    var compact: js.UndefOr[Boolean | String] = js.native
+
+    /** A table may be formatted to emphasize a first column that defines a rows content. */
+    var definition: js.UndefOr[Boolean] = js.native
+
+    /**
+     * A table can use fixed a special faster form of table rendering that does not resize table cells based on content.
+     */
+    var fixed: js.UndefOr[Boolean] = js.native
+
+    /** A table's colors can be inverted. */
+    var inverted: js.UndefOr[Boolean] = js.native
+
+    /** A table may sometimes need to be more padded for legibility. */
+    var padded: js.UndefOr[Boolean | String] = js.native
+
+    /** A table can have its rows appear selectable. */
+    var selectable: js.UndefOr[Boolean] = js.native
+
+    /** A table can specify that its cell contents should remain on a single line and not wrap. */
+    var singleLine: js.UndefOr[Boolean] = js.native
+
+    /** A table can also be small or large. */
+    var size: js.UndefOr[Boolean | String] = js.native
+
+    /** A table may allow a user to sort contents by clicking on a table header. */
+    var sortable: js.UndefOr[Boolean] = js.native
+
+    /** A table can specify how it stacks table content responsively. */
+    var stackable: js.UndefOr[Boolean] = js.native
+
+    /** A table can stripe alternate rows of content with a darker color to increase contrast. */
+    var striped: js.UndefOr[Boolean] = js.native
+
+    /** A table can be formatted to display complex structured data. */
+    var structured: js.UndefOr[Boolean] = js.native
+
+    /** A table can adjust its text alignment. */
+    var textAlign: js.UndefOr[Boolean | String] = js.native
+
+    /** A table can specify how it stacks table content responsively. */
+    var unstackable: js.UndefOr[Boolean] = js.native
+
+    /** A table can adjust its text alignment. */
+    var verticalAlign: js.UndefOr[suiraw.SemanticVERTICALALIGNMENTS]
+  }
+
+  def props[A](q: Table): TableProps = {
+    val p = q.as.toJsObject[TableProps]
+    q.as.toJs.foreach(v => p.as = v)
+    q.attached.toJs.foreach(v => p.attached = v)
+    q.basic.toJs.foreach(v => p.basic = v)
+    q.celled.toJs.foreach(v => p.celled = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.collapsing.foreach(v => p.collapsing = v)
+    q.color.toJs.foreach(v => p.color = v)
+    q.columns.toJs.foreach(v => p.columns = v)
+    q.compact.toJs.foreach(v => p.compact = v)
+    q.definition.foreach(v => p.definition = v)
+    q.fixed.foreach(v => p.fixed = v)
+    q.inverted.foreach(v => p.inverted = v)
+    q.padded.toJs.foreach(v => p.padded = v)
+    q.selectable.foreach(v => p.selectable = v)
+    q.singleLine.foreach(v => p.singleLine = v)
+    q.size.toJs.foreach(v => p.size = v)
+    q.sortable.foreach(v => p.sortable = v)
+    q.stackable.foreach(v => p.stackable = v)
+    q.striped.foreach(v => p.striped = v)
+    q.structured.foreach(v => p.structured = v)
+    q.unstackable.foreach(v => p.unstackable = v)
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign = v)
+    p
+  }
+
+  private val component = JsComponent[TableProps, Children.Varargs, Null](RawComponent)
+
+  def apply[A](mods: TagMod*): Table = Table(modifiers = mods)
+
+}

--- a/facade/src/main/scala/react/semanticui/collections/table/TableBody.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableBody.scala
@@ -1,0 +1,55 @@
+package react.semanticui.collections.table
+
+import scala.scalajs.js
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.raw.React
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common._
+import react.semanticui._
+
+final case class TableBody(
+  as:                     js.UndefOr[AsC] = js.undefined,
+  className:              js.UndefOr[String] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[TableBody.TableBodyProps, TableBody] {
+  override protected def cprops    = TableBody.props(this)
+  override protected val component = TableBody.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
+
+object TableBody {
+  @js.native
+  @JSImport("semantic-ui-react", "TableBody")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait TableBodyProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.native
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.native
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.native
+  }
+
+  def props(q: TableBody): TableBodyProps = {
+    val p = q.as.toJsObject[TableBodyProps]
+    q.as.toJs.foreach(v => p.as = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    p
+  }
+
+  private val component = JsComponent[TableBodyProps, Children.Varargs, Null](RawComponent)
+
+  def apply(mods: TagMod*): TableBody = TableBody(modifiers = mods)
+}

--- a/facade/src/main/scala/react/semanticui/collections/table/TableCell.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableCell.scala
@@ -1,0 +1,128 @@
+package react.semanticui.collections.table
+
+import scala.scalajs.js
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.raw.React
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common._
+import react.semanticui.elements.icon.Icon
+import react.semanticui.elements.icon.Icon.IconProps
+import react.semanticui.{ raw => suiraw }
+import react.semanticui._
+
+final case class TableCell(
+  as:                     js.UndefOr[AsC] = js.undefined,
+  active:                 js.UndefOr[Boolean] = js.undefined,
+  className:              js.UndefOr[String] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  collapsing:             js.UndefOr[Boolean] = js.undefined,
+  content:                js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
+  disabled:               js.UndefOr[Boolean] = js.undefined,
+  error:                  js.UndefOr[Boolean] = js.undefined,
+  icon:                   js.UndefOr[ShorthandS[Icon]] = js.undefined,
+  negative:               js.UndefOr[Boolean] = js.undefined,
+  positive:               js.UndefOr[Boolean] = js.undefined,
+  selectable:             js.UndefOr[Boolean] = js.undefined,
+  singleLine:             js.UndefOr[Boolean] = js.undefined,
+  textAlign:              js.UndefOr[TableTextAlign] = js.undefined,
+  verticalAlign:          js.UndefOr[SemanticVerticalAlignment] = js.undefined,
+  warning:                js.UndefOr[Boolean] = js.undefined,
+  width:                  js.UndefOr[SemanticWidth] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[TableCell.TableCellProps, TableCell] {
+  override protected def cprops    = TableCell.props(this)
+  override protected val component = TableCell.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
+
+object TableCell {
+  @js.native
+  @JSImport("semantic-ui-react", "TableCell")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait TableCellProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.native
+
+    /** Style as the currently chosen item. */
+    var active: js.UndefOr[Boolean] = js.native
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.native
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.native
+
+    /** A table can be collapsing, taking up only as much space as its rows. */
+    var collapsing: js.UndefOr[Boolean] = js.native
+
+    /** Shorthand for primary content. */
+    var content: js.UndefOr[suiraw.SemanticShorthandContent] = js.native
+
+    /** A cell can be disabled. */
+    var disabled: js.UndefOr[Boolean] = js.native
+
+    /** A cell may call attention to an error or a negative value. */
+    var error: js.UndefOr[Boolean] = js.native
+
+    /** Add an Icon by name, props object, or pass an <Icon /> */
+    var icon: js.UndefOr[suiraw.SemanticShorthandItemS[IconProps]] = js.native
+
+    /** A cell may let a user know whether a value is bad. */
+    var negative: js.UndefOr[Boolean] = js.native
+
+    /** A cell may let a user know whether a value is good. */
+    var positive: js.UndefOr[Boolean] = js.native
+
+    /** A cell can be selectable. */
+    var selectable: js.UndefOr[Boolean] = js.native
+
+    /** A cell can specify that its contents should remain on a single line and not wrap. */
+    var singleLine: js.UndefOr[Boolean] = js.native
+
+    /** A table cell can adjust its text alignment. */
+    var textAlign: js.UndefOr[String] = js.native
+
+    /** A table cell can adjust its vertical alignment. */
+    var verticalAlign: js.UndefOr[suiraw.SemanticVERTICALALIGNMENTS] = js.native
+
+    /** A cell may warn a user. */
+    var warning: js.UndefOr[Boolean] = js.native
+
+    /** A table can specify the width of individual columns independently. */
+    var width: js.UndefOr[suiraw.SemanticWIDTHS] = js.native
+  }
+
+  def props(q: TableCell): TableCellProps = {
+    val p = q.as.toJsObject[TableCellProps]
+    q.as.toJs.foreach(v => p.as = v)
+    q.active.foreach(v => p.active = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.collapsing.foreach(v => p.collapsing = v)
+    q.content.toJs.foreach(v => p.content = v)
+    q.disabled.foreach(v => p.disabled = v)
+    q.error.foreach(v => p.error = v)
+    q.icon.toJs.foreach(v => p.icon = v)
+    q.negative.foreach(v => p.negative = v)
+    q.positive.foreach(v => p.positive = v)
+    q.selectable.foreach(v => p.selectable = v)
+    q.singleLine.foreach(v => p.singleLine = v)
+    q.textAlign.toJs.foreach(v => p.textAlign = v)
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign = v)
+    q.warning.foreach(v => p.warning = v)
+    q.width.toJs.foreach(v => p.width = v)
+    p
+  }
+
+  private val component = JsComponent[TableCellProps, Children.Varargs, Null](RawComponent)
+
+  def apply(c: ShorthandS[VdomNode]): TableCell = TableCell(content = c)
+}

--- a/facade/src/main/scala/react/semanticui/collections/table/TableFooter.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableFooter.scala
@@ -1,0 +1,67 @@
+package react.semanticui.collections.table
+
+import scala.scalajs.js
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.raw.React
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.vdom.VdomNode
+import react.common._
+import react.semanticui._
+import react.semanticui.{ raw => suiraw }
+
+final case class TableFooter(
+  as:                     js.UndefOr[AsC] = js.undefined,
+  className:              js.UndefOr[String] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  content:                js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
+  fullWidth:              js.UndefOr[Boolean] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[TableFooter.TableFooterProps, TableFooter] {
+  override protected def cprops    = TableFooter.props(this)
+  override protected val component = TableFooter.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
+
+object TableFooter {
+  @js.native
+  @JSImport("semantic-ui-react", "TableFooter")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait TableFooterProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.native
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.native
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.native
+
+    /** Shorthand for primary content. */
+    var content: js.UndefOr[suiraw.SemanticShorthandContent] = js.native
+
+    /** A definition table can have a full width header or footer, filling in the gap left by the first column. */
+    var fullWidth: js.UndefOr[Boolean] = js.native
+  }
+
+  def props(q: TableFooter): TableFooterProps = {
+    val p = q.as.toJsObject[TableFooterProps]
+    q.as.toJs.foreach(v => p.as = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content = v)
+    q.fullWidth.foreach(v => p.fullWidth = v)
+    p
+  }
+
+  private val component = JsComponent[TableFooterProps, Children.Varargs, Null](RawComponent)
+
+  def apply(mods: TagMod*): TableFooter = TableFooter(modifiers = mods)
+}

--- a/facade/src/main/scala/react/semanticui/collections/table/TableGenerator.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableGenerator.scala
@@ -17,7 +17,7 @@ final case class TableGenerator[A](
   as:                     js.UndefOr[AsC] = js.undefined,
   attached:               js.UndefOr[TableAttached] = js.undefined,
   basic:                  js.UndefOr[TableBasic] = js.undefined,
-  celled:                 js.UndefOr[TableCelled] = js.undefined,
+  celled:                 js.UndefOr[Boolean] = js.undefined,
   className:              js.UndefOr[String] = js.undefined,
   clazz:                  js.UndefOr[Css] = js.undefined,
   collapsing:             js.UndefOr[Boolean] = js.undefined,
@@ -27,7 +27,6 @@ final case class TableGenerator[A](
   definition:             js.UndefOr[Boolean] = js.undefined,
   fixed:                  js.UndefOr[Boolean] = js.undefined,
   footerRow:              js.UndefOr[TableRow] = js.undefined,
-  // headerRow:              js.UndefOr[TableRow] = js.undefined,
   headerRows:             js.UndefOr[Seq[TableRow]] = js.undefined,
   inverted:               js.UndefOr[Boolean] = js.undefined,
   padded:                 js.UndefOr[TablePadded] = js.undefined,
@@ -74,7 +73,7 @@ object TableGenerator {
     var basic: js.UndefOr[Boolean | String] = js.native
 
     /** A table may be divided each row into separate cells. */
-    var celled: js.UndefOr[Boolean | String] = js.native
+    var celled: js.UndefOr[Boolean] = js.native
 
     /** Additional classes. */
     var className: js.UndefOr[String] = js.native
@@ -159,7 +158,7 @@ object TableGenerator {
     q.as.toJs.foreach(v => p.as = v)
     q.attached.toJs.foreach(v => p.attached = v)
     q.basic.toJs.foreach(v => p.basic = v)
-    q.celled.toJs.foreach(v => p.celled = v)
+    q.celled.foreach(v => p.celled = v)
     (q.className, q.clazz).toJs.foreach(v => p.className = v)
     q.collapsing.foreach(v => p.collapsing = v)
     q.color.toJs.foreach(v => p.color = v)

--- a/facade/src/main/scala/react/semanticui/collections/table/TableGenerator.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableGenerator.scala
@@ -1,0 +1,190 @@
+package react.semanticui.collections.table
+
+import scala.scalajs.js
+import js.annotation._
+import js.|
+import js.JSConverters._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common._
+import react.semanticui.{ raw => suiraw }
+import react.semanticui._
+import react.semanticui.collections.table.TableRow.TableRowProps
+
+final case class TableGenerator[A](
+  tableData:              Seq[A],
+  renderBodyRow:          TableGenerator.RenderBodyRow[A],
+  as:                     js.UndefOr[AsC] = js.undefined,
+  attached:               js.UndefOr[TableAttached] = js.undefined,
+  basic:                  js.UndefOr[TableBasic] = js.undefined,
+  celled:                 js.UndefOr[TableCelled] = js.undefined,
+  className:              js.UndefOr[String] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  collapsing:             js.UndefOr[Boolean] = js.undefined,
+  color:                  js.UndefOr[SemanticColor] = js.undefined,
+  columns:                js.UndefOr[SemanticWidth] = js.undefined,
+  compact:                js.UndefOr[TableCompact] = js.undefined,
+  definition:             js.UndefOr[Boolean] = js.undefined,
+  fixed:                  js.UndefOr[Boolean] = js.undefined,
+  footerRow:              js.UndefOr[TableRow] = js.undefined,
+  // headerRow:              js.UndefOr[TableRow] = js.undefined,
+  headerRows:             js.UndefOr[Seq[TableRow]] = js.undefined,
+  inverted:               js.UndefOr[Boolean] = js.undefined,
+  padded:                 js.UndefOr[TablePadded] = js.undefined,
+  selectable:             js.UndefOr[Boolean] = js.undefined,
+  singleLine:             js.UndefOr[Boolean] = js.undefined,
+  size:                   js.UndefOr[TableSize] = js.undefined,
+  sortable:               js.UndefOr[Boolean] = js.undefined,
+  stackable:              js.UndefOr[Boolean] = js.undefined,
+  striped:                js.UndefOr[Boolean] = js.undefined,
+  structured:             js.UndefOr[Boolean] = js.undefined,
+  textAlign:              js.UndefOr[TableTextAlign] = js.undefined,
+  unstackable:            js.UndefOr[Boolean] = js.undefined,
+  verticalAlign:          js.UndefOr[SemanticVerticalAlignment] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPA[TableGenerator.TableGeneratorProps, TableGenerator[A]] {
+  override protected def cprops    = TableGenerator.props((this))
+  override protected val component = TableGenerator.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
+
+object TableGenerator {
+  type RenderBodyRow[A] = (A, Int) => TableRow
+  type RawRenderBodyRow = js.Function2[js.Any, Int, TableRowProps]
+
+  @js.native
+  @JSImport("semantic-ui-react", "Table")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait TableGeneratorProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.native
+
+    /** Attach table to other content */
+    var attached: js.UndefOr[Boolean | String] = js.native
+
+    /** A table can reduce its complexity to increase readability. */
+    var basic: js.UndefOr[Boolean | String] = js.native
+
+    /** A table may be divided each row into separate cells. */
+    var celled: js.UndefOr[Boolean | String] = js.native
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.native
+
+    /** A table can be collapsing, taking up only as much space as its rows. */
+    var collapsing: js.UndefOr[Boolean] = js.native
+
+    /** A table can be given a color to distinguish it from other tables. */
+    var color: js.UndefOr[suiraw.SemanticCOLORS] = js.native
+
+    /** A table can specify its column count to divide its content evenly. */
+    var columns: js.UndefOr[String] = js.native
+
+    /** A table may sometimes need to be more compact to make more rows visible at a time. */
+    var compact: js.UndefOr[Boolean | String] = js.native
+
+    /** A table may be formatted to emphasize a first column that defines a rows content. */
+    var definition: js.UndefOr[Boolean] = js.native
+
+    /**
+     * A table can use fixed a special faster form of table rendering that does not resize table cells based on content.
+     */
+    var fixed: js.UndefOr[Boolean] = js.native
+
+    /** Shorthand for a TableRow to be placed within Table.Footer. */
+    var footerRow: js.UndefOr[TableRow.TableRowProps] = js.native
+
+    /** Shorthand for multiple TableRows to be placed within Table.Header. */
+    var headerRows: js.UndefOr[js.Array[TableRow.TableRowProps]] = js.native
+
+    /** A table's colors can be inverted. */
+    var inverted: js.UndefOr[Boolean] = js.native
+
+    /** A table may sometimes need to be more padded for legibility. */
+    var padded: js.UndefOr[Boolean | String] = js.native
+
+    /**
+     * Mapped over `tableData` and should return shorthand for each Table.Row to be placed within Table.Body.
+     *
+     * @param {*} data - An element in the `tableData` array.
+     * @param {number} index - The index of the current element in `tableData`.
+     * @returns {*} Shorthand for a Table.Row.
+     */
+    var renderBodyRow: RawRenderBodyRow = js.native
+
+    /** A table can have its rows appear selectable. */
+    var selectable: js.UndefOr[Boolean] = js.native
+
+    /** A table can specify that its cell contents should remain on a single line and not wrap. */
+    var singleLine: js.UndefOr[Boolean] = js.native
+
+    /** A table can also be small or large. */
+    var size: js.UndefOr[Boolean | String] = js.native
+
+    /** A table may allow a user to sort contents by clicking on a table header. */
+    var sortable: js.UndefOr[Boolean] = js.native
+
+    /** A table can specify how it stacks table content responsively. */
+    var stackable: js.UndefOr[Boolean] = js.native
+
+    /** A table can stripe alternate rows of content with a darker color to increase contrast. */
+    var striped: js.UndefOr[Boolean] = js.native
+
+    /** A table can be formatted to display complex structured data. */
+    var structured: js.UndefOr[Boolean] = js.native
+
+    /** Data to be passed to the renderBodyRow function. */
+    var tableData: js.UndefOr[js.Array[js.Any]] = js.native
+
+    /** A table can adjust its text alignment. */
+    var textAlign: js.UndefOr[Boolean | String] = js.native
+
+    /** A table can specify how it stacks table content responsively. */
+    var unstackable: js.UndefOr[Boolean] = js.native
+
+    /** A table can adjust its text alignment. */
+    var verticalAlign: js.UndefOr[suiraw.SemanticVERTICALALIGNMENTS]
+  }
+
+  def props[A](q: TableGenerator[A]): TableGeneratorProps = {
+    val p = q.as.toJsObject[TableGeneratorProps]
+    q.as.toJs.foreach(v => p.as = v)
+    q.attached.toJs.foreach(v => p.attached = v)
+    q.basic.toJs.foreach(v => p.basic = v)
+    q.celled.toJs.foreach(v => p.celled = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.collapsing.foreach(v => p.collapsing = v)
+    q.color.toJs.foreach(v => p.color = v)
+    q.columns.toJs.foreach(v => p.columns = v)
+    q.compact.toJs.foreach(v => p.compact = v)
+    q.definition.foreach(v => p.definition = v)
+    q.fixed.foreach(v => p.fixed = v)
+    q.footerRow.foreach(v => p.footerRow = v.props)
+    q.headerRows.map(_.map(_.props).toJSArray).foreach(v => p.headerRows = v)
+    q.inverted.foreach(v => p.inverted = v)
+    q.padded.toJs.foreach(v => p.padded = v)
+    p.renderBodyRow = (item: js.Any, index: Int) =>
+      q.renderBodyRow(item.asInstanceOf[A], index).props
+    q.selectable.foreach(v => p.selectable = v)
+    q.singleLine.foreach(v => p.singleLine = v)
+    q.size.toJs.foreach(v => p.size = v)
+    q.sortable.foreach(v => p.sortable = v)
+    q.stackable.foreach(v => p.stackable = v)
+    q.striped.foreach(v => p.striped = v)
+    q.structured.foreach(v => p.structured = v)
+    p.tableData = q.tableData.map(_.asInstanceOf[js.Any]).toJSArray
+    q.unstackable.foreach(v => p.unstackable = v)
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign = v)
+    p
+  }
+
+  private val component = JsComponent[TableGeneratorProps, Children.None, Null](RawComponent)
+}

--- a/facade/src/main/scala/react/semanticui/collections/table/TableGenerator.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableGenerator.scala
@@ -27,6 +27,7 @@ final case class TableGenerator[A](
   definition:             js.UndefOr[Boolean] = js.undefined,
   fixed:                  js.UndefOr[Boolean] = js.undefined,
   footerRow:              js.UndefOr[TableRow] = js.undefined,
+  headerRow:              js.UndefOr[TableRow] = js.undefined,
   headerRows:             js.UndefOr[Seq[TableRow]] = js.undefined,
   inverted:               js.UndefOr[Boolean] = js.undefined,
   padded:                 js.UndefOr[TablePadded] = js.undefined,
@@ -101,6 +102,9 @@ object TableGenerator {
     /** Shorthand for a TableRow to be placed within Table.Footer. */
     var footerRow: js.UndefOr[TableRow.TableRowProps] = js.native
 
+    /** Shorthand for a TableRow to be placed within Table.Header. */
+    var headerRow: js.UndefOr[TableRow.TableRowProps] = js.native
+
     /** Shorthand for multiple TableRows to be placed within Table.Header. */
     var headerRows: js.UndefOr[js.Array[TableRow.TableRowProps]] = js.native
 
@@ -167,6 +171,7 @@ object TableGenerator {
     q.definition.foreach(v => p.definition = v)
     q.fixed.foreach(v => p.fixed = v)
     q.footerRow.foreach(v => p.footerRow = v.props)
+    q.headerRow.foreach(v => p.headerRow = v.props)
     q.headerRows.map(_.map(_.props).toJSArray).foreach(v => p.headerRows = v)
     q.inverted.foreach(v => p.inverted = v)
     q.padded.toJs.foreach(v => p.padded = v)

--- a/facade/src/main/scala/react/semanticui/collections/table/TableHeader.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableHeader.scala
@@ -1,0 +1,67 @@
+package react.semanticui.collections.table
+
+import scala.scalajs.js
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.raw.React
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.vdom.VdomNode
+import react.common._
+import react.semanticui._
+import react.semanticui.{ raw => suiraw }
+
+final case class TableHeader(
+  as:                     js.UndefOr[AsC] = js.undefined,
+  className:              js.UndefOr[String] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  content:                js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
+  fullWidth:              js.UndefOr[Boolean] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[TableHeader.TableHeaderProps, TableHeader] {
+  override protected def cprops    = TableHeader.props(this)
+  override protected val component = TableHeader.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
+
+object TableHeader {
+  @js.native
+  @JSImport("semantic-ui-react", "TableHeader")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait TableHeaderProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.native
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.native
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.native
+
+    /** Shorthand for primary content. */
+    var content: js.UndefOr[suiraw.SemanticShorthandContent] = js.native
+
+    /** A definition table can have a full width header or footer, filling in the gap left by the first column. */
+    var fullWidth: js.UndefOr[Boolean] = js.native
+  }
+
+  def props(q: TableHeader): TableHeaderProps = {
+    val p = q.as.toJsObject[TableHeaderProps]
+    q.as.toJs.foreach(v => p.as = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.content.toJs.foreach(v => p.content = v)
+    q.fullWidth.foreach(v => p.fullWidth = v)
+    p
+  }
+
+  private val component = JsComponent[TableHeaderProps, Children.Varargs, Null](RawComponent)
+
+  def apply(mods: TagMod*): TableHeader = TableHeader(modifiers = mods)
+}

--- a/facade/src/main/scala/react/semanticui/collections/table/TableHeaderCell.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableHeaderCell.scala
@@ -1,0 +1,133 @@
+package react.semanticui.collections.table
+
+import scala.scalajs.js
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.raw.React
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common._
+import react.semanticui.elements.icon.Icon
+import react.semanticui.elements.icon.Icon.IconProps
+import react.semanticui.{ raw => suiraw }
+import react.semanticui._
+
+final case class TableHeaderCell(
+  as:                     js.UndefOr[AsC] = js.undefined,
+  active:                 js.UndefOr[Boolean] = js.undefined,
+  className:              js.UndefOr[String] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  collapsing:             js.UndefOr[Boolean] = js.undefined,
+  content:                js.UndefOr[ShorthandS[VdomNode]] = js.undefined,
+  disabled:               js.UndefOr[Boolean] = js.undefined,
+  error:                  js.UndefOr[Boolean] = js.undefined,
+  icon:                   js.UndefOr[ShorthandS[Icon]] = js.undefined,
+  negative:               js.UndefOr[Boolean] = js.undefined,
+  positive:               js.UndefOr[Boolean] = js.undefined,
+  selectable:             js.UndefOr[Boolean] = js.undefined,
+  singleLine:             js.UndefOr[Boolean] = js.undefined,
+  sorted:                 js.UndefOr[TableSorted] = js.undefined,
+  textAlign:              js.UndefOr[TableTextAlign] = js.undefined,
+  verticalAlign:          js.UndefOr[SemanticVerticalAlignment] = js.undefined,
+  warning:                js.UndefOr[Boolean] = js.undefined,
+  width:                  js.UndefOr[SemanticWidth] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[TableHeaderCell.TableHeaderCellProps, TableHeaderCell] {
+  override protected def cprops    = TableHeaderCell.props(this)
+  override protected val component = TableHeaderCell.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
+
+object TableHeaderCell {
+  @js.native
+  @JSImport("semantic-ui-react", "TableHeaderCell")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait TableHeaderCellProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.native
+
+    /** Style as the currently chosen item. */
+    var active: js.UndefOr[Boolean] = js.native
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.native
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.native
+
+    /** A table can be collapsing, taking up only as much space as its rows. */
+    var collapsing: js.UndefOr[Boolean] = js.native
+
+    /** Shorthand for primary content. */
+    var content: js.UndefOr[suiraw.SemanticShorthandContent] = js.native
+
+    /** A cell can be disabled. */
+    var disabled: js.UndefOr[Boolean] = js.native
+
+    /** A cell may call attention to an error or a negative value. */
+    var error: js.UndefOr[Boolean] = js.native
+
+    /** Add an Icon by name, props object, or pass an <Icon /> */
+    var icon: js.UndefOr[suiraw.SemanticShorthandItemS[IconProps]] = js.native
+
+    /** A cell may let a user know whether a value is bad. */
+    var negative: js.UndefOr[Boolean] = js.native
+
+    /** A cell may let a user know whether a value is good. */
+    var positive: js.UndefOr[Boolean] = js.native
+
+    /** A cell can be selectable. */
+    var selectable: js.UndefOr[Boolean] = js.native
+
+    /** A cell can specify that its contents should remain on a single line and not wrap. */
+    var singleLine: js.UndefOr[Boolean] = js.native
+
+    /** A header cell can be sorted in ascending or descending order. */
+    var sorted: js.UndefOr[String] = js.native
+
+    /** A table cell can adjust its text alignment. */
+    var textAlign: js.UndefOr[String] = js.native
+
+    /** A table cell can adjust its vertical alignment. */
+    var verticalAlign: js.UndefOr[suiraw.SemanticVERTICALALIGNMENTS] = js.native
+
+    /** A cell may warn a user. */
+    var warning: js.UndefOr[Boolean] = js.native
+
+    /** A table can specify the width of individual columns independently. */
+    var width: js.UndefOr[suiraw.SemanticWIDTHS] = js.native
+  }
+
+  def props(q: TableHeaderCell): TableHeaderCellProps = {
+    val p = q.as.toJsObject[TableHeaderCellProps]
+    q.as.toJs.foreach(v => p.as = v)
+    q.active.foreach(v => p.active = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.collapsing.foreach(v => p.collapsing = v)
+    q.content.toJs.foreach(v => p.content = v)
+    q.disabled.foreach(v => p.disabled = v)
+    q.error.foreach(v => p.error = v)
+    q.icon.toJs.foreach(v => p.icon = v)
+    q.negative.foreach(v => p.negative = v)
+    q.positive.foreach(v => p.positive = v)
+    q.selectable.foreach(v => p.selectable = v)
+    q.singleLine.foreach(v => p.singleLine = v)
+    q.sorted.toJs.foreach(v => p.sorted = v)
+    q.textAlign.toJs.foreach(v => p.textAlign = v)
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign = v)
+    q.warning.foreach(v => p.warning = v)
+    q.width.toJs.foreach(v => p.width = v)
+    p
+  }
+
+  private val component = JsComponent[TableHeaderCellProps, Children.Varargs, Null](RawComponent)
+
+  def apply(c: ShorthandS[VdomNode]): TableHeaderCell = TableHeaderCell(content = c)
+}

--- a/facade/src/main/scala/react/semanticui/collections/table/TableRow.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableRow.scala
@@ -13,7 +13,6 @@ final case class TableRow(
   as:                     js.UndefOr[AsC] = js.undefined,
   active:                 js.UndefOr[Boolean] = js.undefined,
   cellAs:                 js.UndefOr[AsC] = js.undefined,
-  // cells:                  js.UndefOr[Seq[TableCell]] = js.undefined,
   className:              js.UndefOr[String] = js.undefined,
   clazz:                  js.UndefOr[Css] = js.undefined,
   disabled:               js.UndefOr[Boolean] = js.undefined,

--- a/facade/src/main/scala/react/semanticui/collections/table/TableRow.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableRow.scala
@@ -1,0 +1,102 @@
+package react.semanticui.collections.table
+
+import scala.scalajs.js
+import js.annotation._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.raw.React
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common._
+import react.semanticui.{ raw => suiraw }
+import react.semanticui._
+
+final case class TableRow(
+  as:                     js.UndefOr[AsC] = js.undefined,
+  active:                 js.UndefOr[Boolean] = js.undefined,
+  cellAs:                 js.UndefOr[AsC] = js.undefined,
+  // cells:                  js.UndefOr[Seq[TableCell]] = js.undefined,
+  className:              js.UndefOr[String] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  disabled:               js.UndefOr[Boolean] = js.undefined,
+  error:                  js.UndefOr[Boolean] = js.undefined,
+  negative:               js.UndefOr[Boolean] = js.undefined,
+  positive:               js.UndefOr[Boolean] = js.undefined,
+  textAlign:              js.UndefOr[TableTextAlign] = js.undefined,
+  verticalAlign:          js.UndefOr[SemanticVerticalAlignment] = js.undefined,
+  warning:                js.UndefOr[Boolean] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[TableRow.TableRowProps, TableRow] {
+  override protected def cprops    = TableRow.props(this)
+  override protected val component = TableRow.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
+
+object TableRow {
+  @js.native
+  @JSImport("semantic-ui-react", "TableRow")
+  object RawComponent extends js.Object
+
+  @js.native
+  trait TableRowProps extends js.Object {
+    @JSBracketAccess
+    def apply(key: String): js.Any = js.native
+
+    @JSBracketAccess
+    def update(key: String, v: js.Any): Unit = js.native
+
+    /** An element type to render as (string or function). */
+    var as: js.UndefOr[AsT] = js.native
+
+    /** Style as the currently chosen item. */
+    var active: js.UndefOr[Boolean] = js.native
+
+    /** An element type to render as (string or function). */
+    var cellAs: js.UndefOr[AsT] = js.native
+
+    /** Primary content. */
+    var children: js.UndefOr[React.Node] = js.native
+
+    /** Additional classes. */
+    var className: js.UndefOr[String] = js.native
+
+    /** A row can be disabled. */
+    var disabled: js.UndefOr[Boolean] = js.native
+
+    /** A row may call attention to an error or a negative value. */
+    var error: js.UndefOr[Boolean] = js.native
+
+    /** A row may let a user know whether a value is bad. */
+    var negative: js.UndefOr[Boolean] = js.native
+
+    /** A row may let a user know whether a value is good. */
+    var positive: js.UndefOr[Boolean] = js.native
+
+    /** A table row can adjust its text alignment. */
+    var textAlign: js.UndefOr[String] = js.native
+
+    /** A table row can adjust its vertical alignment. */
+    var verticalAlign: js.UndefOr[suiraw.SemanticVERTICALALIGNMENTS] = js.native
+
+    /** A cell may warn a user. */
+    var warning: js.UndefOr[Boolean] = js.native
+  }
+
+  def props(q: TableRow): TableRowProps = {
+    val p = q.as.toJsObject[TableRowProps]
+    q.as.toJs.foreach(v => p.as = v)
+    q.active.foreach(v => p.active = v)
+    q.cellAs.toJs.foreach(v => p.cellAs = v)
+    (q.className, q.clazz).toJs.foreach(v => p.className = v)
+    q.disabled.foreach(v => p.disabled = v)
+    q.error.foreach(v => p.error = v)
+    q.negative.foreach(v => p.negative = v)
+    q.positive.foreach(v => p.positive = v)
+    q.textAlign.toJs.foreach(v => p.textAlign = v)
+    q.verticalAlign.toJs.foreach(v => p.verticalAlign = v)
+    q.warning.foreach(v => p.warning = v)
+    p
+  }
+
+  private val component = JsComponent[TableRowProps, Children.Varargs, Null](RawComponent)
+
+  def apply(mods: TagMod*): TableRow = TableRow(modifiers = mods)
+}

--- a/facade/src/main/scala/react/semanticui/collections/table/TableRow.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/TableRow.scala
@@ -2,6 +2,8 @@ package react.semanticui.collections.table
 
 import scala.scalajs.js
 import js.annotation._
+import js.|
+import js.JSConverters._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.raw.React
 import japgolly.scalajs.react.vdom.html_<^._
@@ -13,6 +15,7 @@ final case class TableRow(
   as:                     js.UndefOr[AsC] = js.undefined,
   active:                 js.UndefOr[Boolean] = js.undefined,
   cellAs:                 js.UndefOr[AsC] = js.undefined,
+  cells:                  js.UndefOr[Seq[TableCell | TableHeaderCell]] = js.undefined,
   className:              js.UndefOr[String] = js.undefined,
   clazz:                  js.UndefOr[Css] = js.undefined,
   disabled:               js.UndefOr[Boolean] = js.undefined,
@@ -51,6 +54,11 @@ object TableRow {
     /** An element type to render as (string or function). */
     var cellAs: js.UndefOr[AsT] = js.native
 
+    /** Shorthand array of props for TableCell. */
+    var cells
+      : js.UndefOr[js.Array[TableCell.TableCellProps | TableHeaderCell.TableHeaderCellProps]] =
+      js.native
+
     /** Primary content. */
     var children: js.UndefOr[React.Node] = js.native
 
@@ -84,6 +92,14 @@ object TableRow {
     q.as.toJs.foreach(v => p.as = v)
     q.active.foreach(v => p.active = v)
     q.cellAs.toJs.foreach(v => p.cellAs = v)
+    q.cells
+      .map(_.map[TableCell.TableCellProps | TableHeaderCell.TableHeaderCellProps] { x =>
+        (x: Any) match {
+          case tc: TableCell        => tc.props
+          case thc: TableHeaderCell => thc.props
+        }
+      }.toJSArray)
+      .foreach(v => p.cells = v)
     (q.className, q.clazz).toJs.foreach(v => p.className = v)
     q.disabled.foreach(v => p.disabled = v)
     q.error.foreach(v => p.error = v)

--- a/facade/src/main/scala/react/semanticui/collections/table/package.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/package.scala
@@ -37,14 +37,6 @@ package table {
     case object Very     extends TableBasic
   }
 
-  sealed trait TableCelled
-  object TableCelled {
-    implicit val enum: EnumValueB[TableCelled] = EnumValueB.toLowerCaseStringTF(Celled, NotCelled)
-    case object Celled     extends TableCelled
-    case object NotCelled  extends TableCelled
-    case object Internally extends TableCelled
-  }
-
   sealed trait TableCompact
   object TableCompact {
     implicit val enum: EnumValueB[TableCompact] =

--- a/facade/src/main/scala/react/semanticui/collections/table/package.scala
+++ b/facade/src/main/scala/react/semanticui/collections/table/package.scala
@@ -1,0 +1,71 @@
+package react.semanticui.collections
+
+import react.common.EnumValue
+import react.common.EnumValueB
+
+package table {
+  sealed trait TableTextAlign
+  object TableTextAlign {
+    implicit val enum: EnumValue[TableTextAlign] = EnumValue.toLowerCaseString
+    case object Center extends TableTextAlign
+    case object Left   extends TableTextAlign
+    case object Right  extends TableTextAlign
+  }
+
+  sealed trait TableSorted
+  object TableSorted {
+    implicit val enum: EnumValue[TableSorted] = EnumValue.toLowerCaseString
+    case object Ascending  extends TableSorted
+    case object Descending extends TableSorted
+  }
+
+  sealed trait TableAttached
+  object TableAttached {
+    implicit val enum: EnumValueB[TableAttached] =
+      EnumValueB.toLowerCaseStringTF(Attached, NotAttached)
+    case object Attached    extends TableAttached
+    case object NotAttached extends TableAttached
+    case object Top         extends TableAttached
+    case object Bottom      extends TableAttached
+  }
+
+  sealed trait TableBasic
+  object TableBasic {
+    implicit val enum: EnumValueB[TableBasic] = EnumValueB.toLowerCaseStringTF(Basic, NotBasic)
+    case object Basic    extends TableBasic
+    case object NotBasic extends TableBasic
+    case object Very     extends TableBasic
+  }
+
+  sealed trait TableCelled
+  object TableCelled {
+    implicit val enum: EnumValueB[TableCelled] = EnumValueB.toLowerCaseStringTF(Celled, NotCelled)
+    case object Celled     extends TableCelled
+    case object NotCelled  extends TableCelled
+    case object Internally extends TableCelled
+  }
+
+  sealed trait TableCompact
+  object TableCompact {
+    implicit val enum: EnumValueB[TableCompact] =
+      EnumValueB.toLowerCaseStringTF(Compact, NotCompact)
+    case object Compact    extends TableCompact
+    case object NotCompact extends TableCompact
+    case object Very       extends TableCompact
+  }
+
+  sealed trait TablePadded
+  object TablePadded {
+    implicit val enum: EnumValueB[TablePadded] = EnumValueB.toLowerCaseStringTF(Padded, NotPadded)
+    case object Padded    extends TablePadded
+    case object NotPadded extends TablePadded
+    case object Very      extends TablePadded
+  }
+
+  sealed trait TableSize
+  object TableSize {
+    implicit val enum: EnumValue[TableSize] = EnumValue.toLowerCaseString
+    case object Small extends TableSize
+    case object Large extends TableSize
+  }
+}

--- a/facade/src/test/scala/react/semanticui/collections/table/TableBodyTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableBodyTests.scala
@@ -1,0 +1,20 @@
+package react.semanticui.collections.table
+
+import japgolly.scalajs.react.test._
+import utest._
+
+object TableBodyTests extends TestSuite {
+  val tests = Tests {
+    test("TableBody") {
+      val row1 = TableRow(TableCell("one"))
+      val row2 = TableRow(TableCell("two"))
+      val body = TableBody(row1, row2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        body.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tbody class=""><tr class=""><td class="">one</td></tr><tr class=""><td class="">two</td></tr></tbody>"""
+        )
+      }
+    }
+  }
+}

--- a/facade/src/test/scala/react/semanticui/collections/table/TableCellTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableCellTests.scala
@@ -1,0 +1,146 @@
+package react.semanticui.collections.table
+
+import japgolly.scalajs.react.test._
+import japgolly.scalajs.react.vdom.html_<^._
+import react.semanticui.elements.icon._
+import react.semanticui.verticalalignment
+import react.semanticui.widths
+import utest._
+
+object TableCellTests extends TestSuite {
+  val tests = Tests {
+    test("default") {
+      val cell = TableCell(content = "Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="">Some Content</td>""")
+      }
+    }
+    test("object apply") {
+      val cell = TableCell("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="">Some Content</td>""")
+      }
+    }
+    test("active") {
+      val cell = TableCell(active = true, content = <.div("Some Content"))
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="active"><div>Some Content</div></td>""")
+      }
+    }
+    test("collapsing") {
+      val cell = TableCell(collapsing = true, content = "Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="collapsing">Some Content</td>""")
+      }
+    }
+    test("disabled") {
+      val cell = TableCell(disabled = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="disabled">Some Content</td>""")
+      }
+    }
+    test("error") {
+      val cell = TableCell(error = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="error">Some Content</td>""")
+      }
+    }
+    test("icon") {
+      val cell = TableCell(icon = Icon("edit"), content = "Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<td class=""><i aria-hidden="true" class="edit icon"></i>Some Content</td>"""
+        )
+      }
+    }
+    test("negative") {
+      val cell = TableCell(negative = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="negative">Some Content</td>""")
+      }
+    }
+    test("positive") {
+      val cell = TableCell(positive = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="positive">Some Content</td>""")
+      }
+    }
+    test("selectable") {
+      val cell = TableCell(selectable = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="selectable">Some Content</td>""")
+      }
+    }
+    test("singleLine") {
+      val cell = TableCell(singleLine = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="single line">Some Content</td>""")
+      }
+    }
+    test("textAlign Center") {
+      val cell = TableCell(textAlign = TableTextAlign.Center)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="center aligned">Some Content</td>""")
+      }
+    }
+    test("textAlign Right") {
+      val cell = TableCell(textAlign = TableTextAlign.Right)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="right aligned">Some Content</td>""")
+      }
+    }
+    test("textAlign Left") {
+      val cell = TableCell(textAlign = TableTextAlign.Left)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="left aligned">Some Content</td>""")
+      }
+    }
+    test("verticalAlign") {
+      val cell = TableCell(verticalAlign = verticalalignment.Top)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="top aligned">Some Content</td>""")
+      }
+    }
+    test("aligned both") {
+      val cell =
+        TableCell(textAlign = TableTextAlign.Center, verticalAlign = verticalalignment.Middle)(
+          "Some Content"
+        )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<td class="center aligned middle aligned">Some Content</td>"""
+        )
+      }
+    }
+    test("warning") {
+      val cell = TableCell(warning = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="warning">Some Content</td>""")
+      }
+    }
+    test("width") {
+      val cell = TableCell(width = widths.One)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<td class="one wide">Some Content</td>""")
+      }
+    }
+  }
+}

--- a/facade/src/test/scala/react/semanticui/collections/table/TableFooterTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableFooterTests.scala
@@ -1,0 +1,31 @@
+package react.semanticui.collections.table
+
+import japgolly.scalajs.react.test._
+import utest._
+
+object TableFooterTests extends TestSuite {
+  val tests = Tests {
+    test("TableFooter") {
+      val row1 = TableRow(TableCell("one"))
+      val row2 = TableRow(TableCell("two"))
+      val body = TableFooter(row1, row2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        body.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tfoot class=""><tr class=""><td class="">one</td></tr><tr class=""><td class="">two</td></tr></tfoot>"""
+        )
+      }
+    }
+    test("fullWidth") {
+      val row1 = TableRow(TableCell("one"))
+      val row2 = TableRow(TableCell("two"))
+      val body = TableFooter(fullWidth = true)(row1, row2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        body.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tfoot class="full-width"><tr class=""><td class="">one</td></tr><tr class=""><td class="">two</td></tr></tfoot>"""
+        )
+      }
+    }
+  }
+}

--- a/facade/src/test/scala/react/semanticui/collections/table/TableGeneratorTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableGeneratorTests.scala
@@ -5,9 +5,26 @@ import utest._
 
 object TableGeneratorTests extends TestSuite {
   val tests = Tests {
-    test("TableGenerator") {
+    test("TableGenerator headerRow") {
       def makeRow(a: String, i: Int) = TableRow(TableCell(i.toString), TableCell(a))
-      val headerRows = Seq(TableRow(TableHeaderCell("Generated")))
+      val headerRow = TableRow(TableHeaderCell("header 1"), TableHeaderCell("header 2"))
+      val footerRow = TableRow(TableCell("footer 1"), TableCell("footer 2"))
+      val table     =
+        TableGenerator[String](tableData = Seq("a", "b"),
+                               renderBodyRow = makeRow _,
+                               headerRow = headerRow,
+                               footerRow = footerRow
+        )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui table"><thead class=""><tr class=""><th class="">header 1</th><th class="">header 2</th></tr></thead><tbody class=""><tr class=""><td class="">0</td><td class="">a</td></tr><tr class=""><td class="">1</td><td class="">b</td></tr></tbody><tfoot class=""><tr class=""><td class="">footer 1</td><td class="">footer 2</td></tr></tfoot></table>"""
+        )
+      }
+    }
+    test("TableGenerator headerRows") {
+      def makeRow(a: String, i: Int) = TableRow(TableCell(i.toString), TableCell(a))
+      val headerRows = Seq(TableRow(TableHeaderCell("Row 1")), TableRow(TableHeaderCell("Row 2")))
       val table      =
         TableGenerator[String](tableData = Seq("a", "b"),
                                renderBodyRow = makeRow _,
@@ -16,7 +33,7 @@ object TableGeneratorTests extends TestSuite {
       ReactTestUtils.withNewBodyElement { mountNode =>
         table.renderIntoDOM(mountNode)
         assert(
-          mountNode.innerHTML == """<table class="ui table"><thead class=""><tr class=""><th class="">Generated</th></tr></thead><tbody class=""><tr class=""><td class="">0</td><td class="">a</td></tr><tr class=""><td class="">1</td><td class="">b</td></tr></tbody></table>"""
+          mountNode.innerHTML == """<table class="ui table"><thead class=""><tr class=""><th class="">Row 1</th></tr><tr class=""><th class="">Row 2</th></tr></thead><tbody class=""><tr class=""><td class="">0</td><td class="">a</td></tr><tr class=""><td class="">1</td><td class="">b</td></tr></tbody></table>"""
         )
       }
     }

--- a/facade/src/test/scala/react/semanticui/collections/table/TableGeneratorTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableGeneratorTests.scala
@@ -1,0 +1,24 @@
+package react.semanticui.collections.table
+
+import japgolly.scalajs.react.test._
+import utest._
+
+object TableGeneratorTests extends TestSuite {
+  val tests = Tests {
+    test("TableGenerator") {
+      def makeRow(a: String, i: Int) = TableRow(TableCell(i.toString), TableCell(a))
+      val headerRows = Seq(TableRow(TableHeaderCell("Generated")))
+      val table      =
+        TableGenerator[String](tableData = Seq("a", "b"),
+                               renderBodyRow = makeRow _,
+                               headerRows = headerRows
+        )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui table"><thead class=""><tr class=""><th class="">Generated</th></tr></thead><tbody class=""><tr class=""><td class="">0</td><td class="">a</td></tr><tr class=""><td class="">1</td><td class="">b</td></tr></tbody></table>"""
+        )
+      }
+    }
+  }
+}

--- a/facade/src/test/scala/react/semanticui/collections/table/TableHeaderCellTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableHeaderCellTests.scala
@@ -1,0 +1,162 @@
+package react.semanticui.collections.table
+
+import japgolly.scalajs.react.test._
+import japgolly.scalajs.react.vdom.html_<^._
+import react.semanticui.elements.icon._
+import react.semanticui.verticalalignment
+import react.semanticui.widths
+import utest._
+
+object TableHeaderCellTests extends TestSuite {
+  val tests = Tests {
+    test("default") {
+      val cell = TableHeaderCell(content = "Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="">Some Content</th>""")
+      }
+    }
+    test("object apply") {
+      val cell = TableHeaderCell("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="">Some Content</th>""")
+      }
+    }
+    test("active") {
+      val cell = TableHeaderCell(active = true, content = <.div("Some Content"))
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="active"><div>Some Content</div></th>""")
+      }
+    }
+    test("collapsing") {
+      val cell = TableHeaderCell(collapsing = true, content = "Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="collapsing">Some Content</th>""")
+      }
+    }
+    test("disabled") {
+      val cell = TableHeaderCell(disabled = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="disabled">Some Content</th>""")
+      }
+    }
+    test("error") {
+      val cell = TableHeaderCell(error = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="error">Some Content</th>""")
+      }
+    }
+    test("icon") {
+      val cell = TableHeaderCell(icon = Icon("edit"), content = "Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<th class=""><i aria-hidden="true" class="edit icon"></i>Some Content</th>"""
+        )
+      }
+    }
+    test("negative") {
+      val cell = TableHeaderCell(negative = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="negative">Some Content</th>""")
+      }
+    }
+    test("positive") {
+      val cell = TableHeaderCell(positive = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="positive">Some Content</th>""")
+      }
+    }
+    test("selectable") {
+      val cell = TableHeaderCell(selectable = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="selectable">Some Content</th>""")
+      }
+    }
+    test("singleLine") {
+      val cell = TableHeaderCell(singleLine = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="single line">Some Content</th>""")
+      }
+    }
+    test("sorted ascending") {
+      val cell = TableHeaderCell(sorted = TableSorted.Ascending)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="ascending sorted">Some Content</th>""")
+      }
+    }
+    test("sorted descending") {
+      val cell = TableHeaderCell(sorted = TableSorted.Descending)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="descending sorted">Some Content</th>""")
+      }
+    }
+    test("textAlign Center") {
+      val cell = TableHeaderCell(textAlign = TableTextAlign.Center)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="center aligned">Some Content</th>""")
+      }
+    }
+    test("textAlign Right") {
+      val cell = TableHeaderCell(textAlign = TableTextAlign.Right)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="right aligned">Some Content</th>""")
+      }
+    }
+    test("textAlign Left") {
+      val cell = TableHeaderCell(textAlign = TableTextAlign.Left)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="left aligned">Some Content</th>""")
+      }
+    }
+    test("verticalAlign") {
+      val cell = TableHeaderCell(verticalAlign = verticalalignment.Top)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="top aligned">Some Content</th>""")
+      }
+    }
+    test("aligned both") {
+      val cell =
+        TableHeaderCell(textAlign = TableTextAlign.Center,
+                        verticalAlign = verticalalignment.Middle
+        )(
+          "Some Content"
+        )
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<th class="center aligned middle aligned">Some Content</th>"""
+        )
+      }
+    }
+    test("warning") {
+      val cell = TableHeaderCell(warning = true)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="warning">Some Content</th>""")
+      }
+    }
+    test("width") {
+      val cell = TableHeaderCell(width = widths.One)("Some Content")
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        cell.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<th class="one wide">Some Content</th>""")
+      }
+    }
+  }
+}

--- a/facade/src/test/scala/react/semanticui/collections/table/TableHeaderTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableHeaderTests.scala
@@ -1,0 +1,31 @@
+package react.semanticui.collections.table
+
+import japgolly.scalajs.react.test._
+import utest._
+
+object TableHeaderTests extends TestSuite {
+  val tests = Tests {
+    test("TableHeader") {
+      val row1 = TableRow(TableHeaderCell("one"))
+      val row2 = TableRow(TableHeaderCell("two"))
+      val body = TableHeader(row1, row2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        body.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<thead class=""><tr class=""><th class="">one</th></tr><tr class=""><th class="">two</th></tr></thead>"""
+        )
+      }
+    }
+    test("fullWidth") {
+      val row1 = TableRow(TableHeaderCell("one"))
+      val row2 = TableRow(TableHeaderCell("two"))
+      val body = TableHeader(fullWidth = true)(row1, row2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        body.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<thead class="full-width"><tr class=""><th class="">one</th></tr><tr class=""><th class="">two</th></tr></thead>"""
+        )
+      }
+    }
+  }
+}

--- a/facade/src/test/scala/react/semanticui/collections/table/TableRowTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableRowTests.scala
@@ -32,6 +32,39 @@ object TableRowTests extends TestSuite {
         )
       }
     }
+    test("Two header cells") {
+      val cell1 = TableHeaderCell(content = "High")
+      val cell2 = TableHeaderCell("Low")
+      val row   = TableRow(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class=""><th class="">High</th><th class="">Low</th></tr>"""
+        )
+      }
+    }
+    test("cells property TableCell") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(cells = Seq(cell1, cell2))
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class=""><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("cells property TableHeaderCell") {
+      val cell1 = TableHeaderCell(content = "High")
+      val cell2 = TableHeaderCell(content = "Low")
+      val row   = TableRow(cells = Seq(cell1, cell2))
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class=""><th class="">High</th><th class="">Low</th></tr>"""
+        )
+      }
+    }
     test("object apply") {
       val cell1 = TableCell(content = "High")
       val cell2 = TableCell(content = "Low")

--- a/facade/src/test/scala/react/semanticui/collections/table/TableRowTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableRowTests.scala
@@ -1,0 +1,135 @@
+package react.semanticui.collections.table
+
+import japgolly.scalajs.react.test._
+import react.semanticui.verticalalignment
+import utest._
+
+object TableRowTests extends TestSuite {
+  val tests = Tests {
+    test("No cells") {
+      val row = TableRow()
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<tr class=""></tr>""")
+      }
+    }
+    test("One cell") {
+      val cell = TableCell(content = "Hi")
+      val row  = TableRow(cell)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<tr class=""><td class="">Hi</td></tr>""")
+      }
+    }
+    test("Two cells") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class=""><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("object apply") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class=""><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("active") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(active = true)(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class="active"><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("disabled") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(disabled = true)(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class="disabled"><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("error") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(error = true)(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class="error"><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("negative") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(negative = true)(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class="negative"><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("positive") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(positive = true)(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class="positive"><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("textAlign") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(textAlign = TableTextAlign.Right)(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class="right aligned"><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("verticalAlign") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(verticalAlign = verticalalignment.Bottom)(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class="bottom aligned"><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+    test("warning") {
+      val cell1 = TableCell(content = "High")
+      val cell2 = TableCell(content = "Low")
+      val row   = TableRow(warning = true)(cell1, cell2)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        row.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<tr class="warning"><td class="">High</td><td class="">Low</td></tr>"""
+        )
+      }
+    }
+  }
+}

--- a/facade/src/test/scala/react/semanticui/collections/table/TableTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableTests.scala
@@ -1,8 +1,6 @@
 package react.semanticui.collections.table
 
 import japgolly.scalajs.react.test._
-// import japgolly.scalajs.react.vdom.html_<^._
-// import react.semanticui.verticalalignment
 import utest._
 
 object TableTests extends TestSuite {

--- a/facade/src/test/scala/react/semanticui/collections/table/TableTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/table/TableTests.scala
@@ -1,0 +1,125 @@
+package react.semanticui.collections.table
+
+import japgolly.scalajs.react.test._
+// import japgolly.scalajs.react.vdom.html_<^._
+// import react.semanticui.verticalalignment
+import utest._
+
+object TableTests extends TestSuite {
+  val tests = Tests {
+    test("Table") {
+      val header = TableHeader(TableRow(TableHeaderCell("header")))
+      val body   = TableBody(TableRow(TableCell("A cell")))
+      val footer = TableFooter(TableRow(TableCell("footer")))
+      val table  = Table(header, body, footer)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui table"><thead class=""><tr class=""><th class="">header</th></tr></thead><tbody class=""><tr class=""><td class="">A cell</td></tr></tbody><tfoot class=""><tr class=""><td class="">footer</td></tr></tfoot></table>"""
+        )
+      }
+    }
+    test("TableAttached.Attached") {
+      val header = TableHeader(TableRow(TableHeaderCell("header")))
+      val body   = TableBody(TableRow(TableCell("A cell")))
+      val footer = TableFooter(TableRow(TableCell("footer")))
+      val table  = Table(attached = TableAttached.Attached)(header, body, footer)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui attached table"><thead class=""><tr class=""><th class="">header</th></tr></thead><tbody class=""><tr class=""><td class="">A cell</td></tr></tbody><tfoot class=""><tr class=""><td class="">footer</td></tr></tfoot></table>"""
+        )
+      }
+    }
+    test("TableAttached.NotAttached") {
+      val table = Table(attached = TableAttached.NotAttached)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("TableAttached.Top") {
+      val table = Table(attached = TableAttached.Top)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui top attached table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("TableAttached.Bottom") {
+      val table = Table(attached = TableAttached.Bottom)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui bottom attached table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("TableBasic.Basic") {
+      val table = Table(basic = TableBasic.Basic)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui basic table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("TableBasic.VeryBasic") {
+      val table = Table(basic = TableBasic.Very)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui very basic table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("TableBasic.NotBasic") {
+      val table = Table(basic = TableBasic.NotBasic)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("Table celled") {
+      val table = Table(celled = true)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui celled table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("Table not celled") {
+      val table = Table(celled = false)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("Table collapsing") {
+      val table = Table(collapsing = true)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui collapsing table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+    test("Table not collapsing") {
+      val table = Table(collapsing = false)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        table.renderIntoDOM(mountNode)
+        assert(
+          mountNode.innerHTML == """<table class="ui table"><tbody class=""></tbody></table>"""
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Still need to write tests for a couple of classes, but wanted to get this started...

The JS version has a single `Table` class, but there are 2 incompatible ways of using it.

1) Make TableHeader, TableBody and TableFooter elements children of the Table.
2) Provide a sequence of data and a row generation function. Headers and footers are added via properties on the case class.

If these 2 approaches are mixed, an error is printed to the console at runtime, and things do not work as expected. So, I opted to make a different class for each approach,`Table` and `TableGenerator`, to make it safer to use.

See additional incompatibility notes on individual files.
