### PR TITLE
Minor fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ local.*
 node_modules/
 package-lock.json
 yarn.lock
+.bsp/
+.vscode/
 
 # Hydra
 .hydra/

--- a/facade/src/main/scala/react/semanticui/elements/button/Button.scala
+++ b/facade/src/main/scala/react/semanticui/elements/button/Button.scala
@@ -41,7 +41,7 @@ final case class Button(
   onClick:                js.UndefOr[Callback] = js.undefined,
   positive:               js.UndefOr[Boolean] = js.undefined,
   primary:                js.UndefOr[Boolean] = js.undefined,
-  role:                   js.UndefOr[Boolean] = js.undefined,
+  role:                   js.UndefOr[String] = js.undefined,
   secondary:              js.UndefOr[Boolean] = js.undefined,
   size:                   js.UndefOr[SemanticSize] = js.undefined,
   tabIndex:               js.UndefOr[TabIndex] = js.undefined,
@@ -91,7 +91,7 @@ object Button {
     var onClick: js.UndefOr[js.Function2[ReactMouseEvent, ButtonProps, Unit]] = js.native
     var positive: js.UndefOr[Boolean]                                         = js.native
     var primary: js.UndefOr[Boolean]                                          = js.native
-    var role: js.UndefOr[Boolean]                                             = js.native
+    var role: js.UndefOr[String]                                              = js.native
     var secondary: js.UndefOr[Boolean]                                        = js.native
     var size: js.UndefOr[suiraw.SemanticSIZES]                                = js.native
     var tabIndex: js.UndefOr[Double | String]                                 = js.native
@@ -156,7 +156,7 @@ object Button {
     onClick:       js.UndefOr[Callback] = js.undefined,
     positive:      js.UndefOr[Boolean] = js.undefined,
     primary:       js.UndefOr[Boolean] = js.undefined,
-    role:          js.UndefOr[Boolean] = js.undefined,
+    role:          js.UndefOr[String] = js.undefined,
     secondary:     js.UndefOr[Boolean] = js.undefined,
     size:          js.UndefOr[SemanticSize] = js.undefined,
     tabIndex:      js.UndefOr[TabIndex] = js.undefined,

--- a/facade/src/main/scala/react/semanticui/package.scala
+++ b/facade/src/main/scala/react/semanticui/package.scala
@@ -272,8 +272,8 @@ package object semanticui {
   type AsT   = String | AsFn | AsObj
   type AsC   = String | As
 
-  implicit def tagOf2AsC[N <: TopNode](tagOf: TagOf[N]): js.UndefOr[AsC] =
-    As.AsTag(tagOf)
+  implicit def tagOf2AsC[T, N <: TopNode](tagOf: T)(implicit ev: T => TagOf[N]): js.UndefOr[AsC] =
+    As.AsTag(ev(tagOf))
 
   implicit class AsCUndef[T](val c: js.UndefOr[AsC]) extends AnyVal {
     def toJs: js.UndefOr[AsT] =

--- a/facade/src/test/scala/react/semanticui/collections/menu/MenuHeaderTests.scala
+++ b/facade/src/test/scala/react/semanticui/collections/menu/MenuHeaderTests.scala
@@ -20,5 +20,12 @@ object MenuHeaderTests extends TestSuite {
         assert(mountNode.innerHTML == """<a class="header"></a>""")
       }
     }
+    test("renderAsHTMLTag") {
+      val menuHeader = MenuHeader(as = <.div)
+      ReactTestUtils.withNewBodyElement { mountNode =>
+        menuHeader.renderIntoDOM(mountNode)
+        assert(mountNode.innerHTML == """<div class="header"></div>""")
+      }
+    }
   }
 }


### PR DESCRIPTION
- In some cases, `as = <.tag` wasn't working. This is because some `tag`s are defined as `HtmlTagOf` instead of `TagOf` and implicit conversion must happen into `TagOf`.
- `role` property of `Button` is a `String`.