### PR TITLE
Add `placeholder` to FormInput facade

### DIFF
--- a/facade/src/main/scala/react/semanticui/collections/form/FormInput.scala
+++ b/facade/src/main/scala/react/semanticui/collections/form/FormInput.scala
@@ -36,6 +36,7 @@ final case class FormInput(
   loading:                js.UndefOr[Boolean] = js.undefined,
   onChange:               js.UndefOr[Callback] = js.undefined,
   onChangeE:              js.UndefOr[Input.OnChange] = js.undefined,
+  placeholder:            js.UndefOr[String] = js.undefined,
   required:               js.UndefOr[Boolean] = js.undefined,
   size:                   js.UndefOr[SemanticSize] = js.undefined,
   tabIndex:               js.UndefOr[String | Double] = js.undefined,
@@ -145,6 +146,9 @@ object FormInput {
      */
     var onChange: js.UndefOr[js.Function1[ReactEventFromInput, Unit]]
 
+    /** Placeholder text. */
+    var placeholder: js.UndefOr[String] = js.native
+
     /** An Input can vary in size. */
     var size: js.UndefOr[suiraw.SemanticSIZES] = js.native
 
@@ -181,6 +185,7 @@ object FormInput {
       q.loading,
       q.onChange,
       q.onChangeE,
+      q.placeholder,
       q.required,
       q.size,
       q.tabIndex,
@@ -212,6 +217,7 @@ object FormInput {
     loading:        js.UndefOr[Boolean] = js.undefined,
     onChange:       js.UndefOr[Callback] = js.undefined,
     onChangeE:      js.UndefOr[Input.OnChange] = js.undefined,
+    placeholder:    js.UndefOr[String] = js.undefined,
     required:       js.UndefOr[Boolean] = js.undefined,
     size:           js.UndefOr[SemanticSize] = js.undefined,
     tabIndex:       js.UndefOr[String | Double] = js.undefined,
@@ -248,6 +254,7 @@ object FormInput {
     error.toJs.foreach(v => p.error = v)
     inline.foreach(v => p.inline = v)
     label.toJs.foreach(v => p.label = v)
+    placeholder.foreach(v => p.placeholder = v)
     required.foreach(v => p.required = v)
     p.`type` = tpe
     width.toJs.foreach(v => p.width = v)


### PR DESCRIPTION
The `placeholder` property was just missing in the facade, probably because it wasn't directly on the typescript properties for FormInput, but was inherited from somewhere and was hard to find.